### PR TITLE
Fix for C# where clause in prototype functions

### DIFF
--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -284,6 +284,7 @@ static const chunk_tag_t keywords[] =
    { "wchar_t",          CT_TYPE,         LANG_C | LANG_CPP                                                           },
    { "weak",             CT_QUALIFIER,    LANG_VALA                                                                   },
    { "when",             CT_WHEN,         LANG_CS                                                                     },
+   { "where",            CT_WHERE,        LANG_CS                                                                     },
    { "while",            CT_WHILE,        LANG_ALL                                                                    }, // PAWN
    { "with",             CT_D_WITH,       LANG_D | LANG_ECMA                                                          },
    { "xor",              CT_SARITH,       LANG_C | LANG_CPP                                                           },

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -135,6 +135,7 @@ typedef enum
    CT_ATTRIBUTE,
    CT_CATCH,
    CT_WHEN,
+   CT_WHERE,            /* C# where clause */
    CT_CLASS,
    CT_DELETE,
    CT_EXPORT,

--- a/tests/input/staging/UNI-2007.cs
+++ b/tests/input/staging/UNI-2007.cs
@@ -1,0 +1,28 @@
+public class MyGenericClass<T> where T:IComparable { }
+
+class MyClass<T, U>
+    where T : class
+    where U : struct
+{ }
+
+public class MyGenericClass<T> where T : IComparable, new()
+{
+    // The following line is not possible without new() constraint:
+    T item = new T();
+}
+
+interface IMyInterface
+{
+}
+
+class Dictionary<TKey, TVal>
+    where TKey : IComparable, IEnumerable
+    where TVal : IMyInterface
+{
+    public void Add(TKey key, TVal val)
+    {
+    }
+}
+
+extern T GetNodeFromGuid<T>(Guid guid) where T : INode;
+extern T GetNodeFromGuid<T>(Guid guid) where T: INode;

--- a/tests/output/staging/10072-UNI-2007.cs
+++ b/tests/output/staging/10072-UNI-2007.cs
@@ -1,0 +1,31 @@
+public class MyGenericClass<T> where T : IComparable
+{
+}
+
+class MyClass<T, U>
+    where T : class
+    where U : struct
+{
+}
+
+public class MyGenericClass<T> where T : IComparable, new()
+{
+    // The following line is not possible without new() constraint:
+    T item = new T();
+}
+
+interface IMyInterface
+{
+}
+
+class Dictionary<TKey, TVal>
+    where TKey : IComparable, IEnumerable
+    where TVal : IMyInterface
+{
+    public void Add(TKey key, TVal val)
+    {
+    }
+}
+
+extern T GetNodeFromGuid<T>(Guid guid) where T : INode;
+extern T GetNodeFromGuid<T>(Guid guid) where T : INode;


### PR DESCRIPTION
Made `where` a C# token and moved the function markup to a dedicated place to handle `where` generic type constraint in proto functions as well.

I've made this PR against the main `upstream-merge-dev` branch because it's basically modifying our patches.
