### PR TITLE
if we're trying to redirect a preprocessor directive to PP_IGNORE, th…

### DIFF
--- a/src/keywords.cpp
+++ b/src/keywords.cpp
@@ -403,7 +403,7 @@ static const chunk_tag_t *kw_static_match(const chunk_tag_t *tag)
  * @param len     The length of the text
  * @return        CT_WORD (no match) or the keyword token
  */
-c_token_t find_keyword_type(const char *word, int len)
+c_token_t find_keyword_type(const char *word, int len, bool enableDynamicSubstitution)
 {
    string            ss(word, len);
    chunk_tag_t       key;
@@ -415,10 +415,13 @@ c_token_t find_keyword_type(const char *word, int len)
    }
 
    /* check the dynamic word list first */
-   dkwmap::iterator it = dkwm.find(ss);
-   if (it != dkwm.end())
+   if (enableDynamicSubstitution)
    {
-      return((*it).second);
+	   dkwmap::iterator it = dkwm.find(ss);
+	   if (it != dkwm.end())
+	   {
+		  return((*it).second);
+	   }
    }
 
    key.tag = ss.c_str();

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -188,7 +188,7 @@ void brace_cleanup(void);
  *  keywords.cpp
  */
 int load_keyword_file(const char *filename);
-c_token_t find_keyword_type(const char *word, int len);
+c_token_t find_keyword_type(const char *word, int len, bool doSubstitutions = true);
 void add_keyword(const char *tag, c_token_t type);
 void print_keywords(FILE *pfile);
 void clear_keyword_file(void);

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1227,6 +1227,14 @@ bool parse_word(tok_ctx& ctx, chunk_t& pc, bool skipcheck)
       {
          /* Turn it into a keyword now */
          pc.type = find_keyword_type(pc.text(), pc.str.size());
+
+		 /* Special pattern: if we're trying to redirect a preprocessor directive to PP_IGNORE,
+		    then ensure we're actually part of a preprocessor before doing the swap, or we'll
+			end up with a function named 'define' as PP_IGNORE. This is necessary because with
+			the config 'set' feature, there's no way to do a pair of tokens as a word
+			substitution. */
+		 if (pc.type == CT_PP_IGNORE && !cpd.in_preproc)
+			 pc.type = find_keyword_type(pc.text(), pc.str.size(), false);
       }
    }
 


### PR DESCRIPTION
…en ensure we're actually part of a preprocessor before doing the swap, or we'll end up with a function named 'define' as PP_IGNORE. This is necessary because with the config 'set' feature, there's no way to do a pair of tokens as a word substitution.

This is not for upstream
