### PR TITLE
Add crash handling for Windows (and later for other OS's) so that we …

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -230,6 +230,52 @@ static void redir_stdout(const char *output_file)
    }
 }
 
+#ifdef WIN32
+
+void setup_crash_handling()
+{
+   // prevent crash popup. uncrustify is a batch processing tool and a popup is unacceptable.
+   ::SetErrorMode(::GetErrorMode() | SEM_NOGPFAULTERRORBOX);
+
+   struct local
+   {
+      static LONG WINAPI crash_filter(_In_ struct _EXCEPTION_POINTERS* exceptionInfo)
+      {
+         __try
+         {
+            LOG_FMT(LERR, "crash_filter: exception 0x%08X at [%d:%d] (ip=%p)",
+               exceptionInfo->ExceptionRecord->ExceptionCode,
+               cpd.line_number, cpd.column,
+               exceptionInfo->ExceptionRecord->ExceptionAddress);
+            log_func_stack(LERR, " [CallStack:", "]\n", 0);
+
+            // treat an exception the same as a parse failure. exceptions can result from parse failures where we
+            // do not have specific handling (null-checks for particular parse paths etc.) and callers generally
+            // won't care about the difference. they just want to know it failed.
+            exit(EXIT_FAILURE);
+         }
+         __except(EXCEPTION_EXECUTE_HANDLER)
+         {
+            // have to be careful of crashes in crash handling code
+         }
+
+         // safety - note that this will not flush like we need, but at least will get the right return code
+         ::ExitProcess(EXIT_FAILURE);
+      }
+   };
+
+   // route all crashes through our own handler
+   ::SetUnhandledExceptionFilter(local::crash_filter);
+}
+
+#else
+
+void setup_crash_handling()
+{
+   // TODO: unixes
+}
+
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -241,6 +287,8 @@ int main(int argc, char *argv[])
    log_mask_t mask;
    int        idx;
    const char *p_arg;
+
+   setup_crash_handling();
 
    /* check keyword sort */
    assert(keywords_are_sorted());


### PR DESCRIPTION
…do not bring up the pop-up system exception reporting dialog, but also try to represent the crash the same way as any other parse error. Crashes very often occur because of unexpected paths through parse code, and end users aren't interested in crashes, they need to know it simply fails.
