### PR TITLE
Avoid formatting the body of a define

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2105,7 +2105,7 @@ void indent_text(void)
             }
 
             /* [Unity-only hack] Do nothing. We're using 'define' as CT_PP_IGNORE to avoid reformatting of complex and weird macros. Likewise leave indentation alone because probably also weird. */
-            for (chunk_t* i = prev; i; i = i->prev)
+            for (chunk_t* i = pc; i; i = i->prev)
             {
                if (i->type == CT_PP_IGNORE)
                {

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -2104,23 +2104,10 @@ void indent_text(void)
                }
             }
 
-            /* [Unity-only hack] Do nothing. We're using 'define' as CT_PP_IGNORE to avoid reformatting of complex and weird macros. Likewise leave indentation alone because probably also weird. */
-            for (chunk_t* i = pc; i; i = i->prev)
-            {
-               if (i->type == CT_PP_IGNORE)
-               {
-                  use_ident = false;
-                  break;
-               }
-               else if (i->type != CT_PREPROC_BODY)
-               {
-                  break;
-               }
-            }
-
             if (pc->column != indent_column)
             {
-               if (use_ident)
+               if (use_ident &&
+                   pc->type != CT_PP_IGNORE) // Leave indentation alone for PP_IGNORE tokens
                {
                   LOG_FMT(LINDENT, "%s[line %d]: %d] indent => %d [%s]\n",
                           __func__, __LINE__, pc->orig_line, indent_column, pc->text());

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1467,6 +1467,8 @@ void register_options(void)
                   "Control whether to indent the code between #if, #else and #endif.");
    unc_add_option("pp_define_at_level", UO_pp_define_at_level, AT_BOOL,
                   "Whether to indent '#define' at the brace level (true) or from column 1 (false)");
+   unc_add_option("pp_ignore_define_body", UO_pp_ignore_define_body, AT_BOOL,
+                  "Whether to ignore the '#define' body while formatting.");
 
    unc_begin_group(UG_Use_Ext, "Use or Do not Use options", "G");
    unc_add_option("use_indent_func_call_param", UO_use_indent_func_call_param, AT_BOOL,

--- a/src/options.h
+++ b/src/options.h
@@ -134,6 +134,7 @@ enum uncrustify_options
    UO_pp_region_indent_code,     // whether to indent the code inside region stuff
    UO_pp_indent_if,
    UO_pp_if_indent_code,
+   UO_pp_ignore_define_body,      // ignore processing define body
 
    UO_indent_switch_case,         // spaces to indent case from switch
    UO_indent_case_shift,          // spaces to shift the line with the 'case'

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -337,21 +337,30 @@ void output_text(FILE *pfile)
             }
             else
             {
-               /* Try to keep the same relative spacing */
                prev = chunk_get_prev(pc);
-               while ((prev != NULL) && (prev->orig_col == 0) && (prev->nl_count == 0))
-               {
-                  prev = chunk_get_prev(prev);
-               }
 
-               if ((prev != NULL) && (prev->nl_count == 0))
+               if (prev && prev->type == CT_PP_IGNORE)
                {
-                  int orig_sp = (pc->orig_col - prev->orig_col_end);
-                  pc->column = cpd.column + orig_sp;
-                  if ((cpd.settings[UO_sp_before_nl_cont].a != AV_IGNORE) &&
-                      (pc->column < (cpd.column + 1)))
+                  /* Want to completely leave alone PP_IGNORE'd blocks because they likely have special column aligned newline continuations (common in multiline macros) */
+                  pc->column = pc->orig_col;
+               }
+               else
+               {
+                  /* Try to keep the same relative spacing */
+                  while ((prev != NULL) && (prev->orig_col == 0) && (prev->nl_count == 0))
                   {
-                     pc->column = cpd.column + 1;
+                     prev = chunk_get_prev(prev);
+                  }
+
+                  if ((prev != NULL) && (prev->nl_count == 0))
+                  {
+                     int orig_sp = (pc->orig_col - prev->orig_col_end);
+                     pc->column = cpd.column + orig_sp;
+                     if ((cpd.settings[UO_sp_before_nl_cont].a != AV_IGNORE) &&
+                         (pc->column < (cpd.column + 1)))
+                     {
+                        pc->column = cpd.column + 1;
+                     }
                   }
                }
             }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -131,8 +131,9 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
    }
    if ((first->type == CT_PP_IGNORE) && (second->type == CT_PP_IGNORE))
    {
-	   log_rule("PP_IGNORE");
-	   return(AV_IGNORE);
+      // Leave spacing alone between PP_IGNORE tokens as we don't want the default behavior (which is ADD).
+      log_rule("PP_IGNORE");
+      return(AV_IGNORE);
    }
    if ((first->type == CT_PP) || (second->type == CT_PP))
    {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -129,6 +129,11 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
       log_rule("IGNORED");
       return(AV_REMOVE);
    }
+   if ((first->type == CT_PP_IGNORE) && (second->type == CT_PP_IGNORE))
+   {
+	   log_rule("PP_IGNORE");
+	   return(AV_IGNORE);
+   }
    if ((first->type == CT_PP) || (second->type == CT_PP))
    {
       log_rule("sp_pp_concat");

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1228,13 +1228,13 @@ bool parse_word(tok_ctx& ctx, chunk_t& pc, bool skipcheck)
          /* Turn it into a keyword now */
          pc.type = find_keyword_type(pc.text(), pc.str.size());
 
-		 /* Special pattern: if we're trying to redirect a preprocessor directive to PP_IGNORE,
-		    then ensure we're actually part of a preprocessor before doing the swap, or we'll
-			end up with a function named 'define' as PP_IGNORE. This is necessary because with
-			the config 'set' feature, there's no way to do a pair of tokens as a word
-			substitution. */
-		 if (pc.type == CT_PP_IGNORE && !cpd.in_preproc)
-			 pc.type = find_keyword_type(pc.text(), pc.str.size(), false);
+         /* Special pattern: if we're trying to redirect a preprocessor directive to PP_IGNORE,
+             then ensure we're actually part of a preprocessor before doing the swap, or we'll
+            end up with a function named 'define' as PP_IGNORE. This is necessary because with
+            the config 'set' feature, there's no way to do a pair of tokens as a word
+            substitution. */
+         if (pc.type == CT_PP_IGNORE && !cpd.in_preproc)
+            pc.type = find_keyword_type(pc.text(), pc.str.size(), false);
       }
    }
 

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1235,7 +1235,7 @@ bool parse_word(tok_ctx& ctx, chunk_t& pc, bool skipcheck)
          pc.type = find_keyword_type(pc.text(), pc.str.size());
 
          /* Special pattern: if we're trying to redirect a preprocessor directive to PP_IGNORE,
-             then ensure we're actually part of a preprocessor before doing the swap, or we'll
+            then ensure we're actually part of a preprocessor before doing the swap, or we'll
             end up with a function named 'define' as PP_IGNORE. This is necessary because with
             the config 'set' feature, there's no way to do a pair of tokens as a word
             substitution. */

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -1944,7 +1944,7 @@ void tokenize(const deque<int>& data, chunk_t *ref)
          else if (cpd.in_preproc == CT_PP_IGNORE)
          {
             // ASSERT(cpd.settings[UO_pp_ignore_define_body].b);
-            if (pc->type != CT_NL_CONT)
+            if (pc->type != CT_NL_CONT && pc->type != CT_COMMENT_CPP)
                set_chunk_type(pc, CT_PP_IGNORE);
          }
          else if (cpd.in_preproc == CT_PP_DEFINE && pc->type == CT_PAREN_CLOSE

--- a/tests/config/staging/Uncrustify.Common-Cpp.cfg
+++ b/tests/config/staging/Uncrustify.Common-Cpp.cfg
@@ -8,7 +8,7 @@ set COMMENT PLATFORM_EXCEPTION_SAFEGUARD_PROLOG
 # without this, uncrustify will parse and process the contents of #defines, which is super unstable. very easy to get into edge cases it does not support,
 # so just have it treat #defines as black boxes. this 'set' will convert #define to a PP_IGNORE, which keeps all of the contents of the #define as
 # an unparsed PREPROC_BODY, only doing indentation and that's it. note that this causes all define-related options to be ignored.
-set PP_IGNORE define
+# set PP_IGNORE define
 
 # macros in #includes aren't known to Uncrustify, so have to inform it here for macros that will confuse it
 set MACRO_FUNC ATTRIBUTE_ALIGN

--- a/tests/config/staging/Uncrustify.Common-Cpp.cfg
+++ b/tests/config/staging/Uncrustify.Common-Cpp.cfg
@@ -6,9 +6,8 @@ include Uncrustify.Common-CStyle.cfg
 set COMMENT PLATFORM_EXCEPTION_SAFEGUARD_PROLOG
 
 # without this, uncrustify will parse and process the contents of #defines, which is super unstable. very easy to get into edge cases it does not support,
-# so just have it treat #defines as black boxes. this 'set' will convert #define to a PP_IGNORE, which keeps all of the contents of the #define as
-# an unparsed PREPROC_BODY, only doing indentation and that's it. note that this causes all define-related options to be ignored.
-# set PP_IGNORE define
+# so just have it treat #defines as black boxes. this will keep all of the contents of the #define as unprocessed.
+pp_ignore_define_body=true
 
 # macros in #includes aren't known to Uncrustify, so have to inform it here for macros that will confuse it
 set MACRO_FUNC ATTRIBUTE_ALIGN

--- a/tests/input/staging/UNI-1334.cpp
+++ b/tests/input/staging/UNI-1334.cpp
@@ -1,5 +1,7 @@
 // This should not be screwing with the trailing backslash and indentation of contents!
+// unless it's on the first line where it's controlled by sp_before_nl_cont which we have set on add.
+// Devs should expect misalignment of the nl_cont tokens because we're not messing with the nl_cont from the define body.
 
 #define MY_DEFINE(param1, param2)\
-	foo(param1);\
+	my_long_foo_function(param1);\
 	bar(param2);

--- a/tests/input/staging/pp-ignore.mm
+++ b/tests/input/staging/pp-ignore.mm
@@ -1,0 +1,29 @@
+#define a	z	\
+			x
+
+#define a(b)	z	\
+				x
+
+#define ab(b)	z	\
+				x
+
+#define abc(b)	z	\
+				x
+
+#define abcd(b)	z	\
+				x
+
+
+#if FOO
+#	define D(a, ...) B(FOO(a, __LINE__, __VA_ARGS__))
+#	define C(msg)			\
+		PP_WRAP_CODE(		\
+			if (!msg)		\
+			{				\
+				BAR();		\
+				BARBAR();	\
+				BARBARBAR();\
+			})
+#else
+#	define C(msg, ...)		EMPTY
+#endif

--- a/tests/output/staging/10047-UNI-1334.cpp
+++ b/tests/output/staging/10047-UNI-1334.cpp
@@ -1,5 +1,7 @@
 // This should not be screwing with the trailing backslash and indentation of contents!
+// unless it's on the first line where it's controlled by sp_before_nl_cont which we have set on add.
+// Devs should expect misalignment of the nl_cont tokens because we're not messing with the nl_cont from the define body.
 
 #define MY_DEFINE(param1, param2) \
-    foo(param1);\
+    my_long_foo_function(param1);\
     bar(param2);

--- a/tests/output/staging/10047-UNI-1334.cpp
+++ b/tests/output/staging/10047-UNI-1334.cpp
@@ -1,5 +1,5 @@
 // This should not be screwing with the trailing backslash and indentation of contents!
 
-#define MY_DEFINE(param1, param2)\
+#define MY_DEFINE(param1, param2) \
     foo(param1);\
     bar(param2);

--- a/tests/output/staging/10102-pp-ignore.mm
+++ b/tests/output/staging/10102-pp-ignore.mm
@@ -1,0 +1,29 @@
+#define a   z   \
+            x
+
+#define a(b)    z   \
+                x
+
+#define ab(b)   z   \
+                x
+
+#define abc(b)  z   \
+                x
+
+#define abcd(b) z   \
+                x
+
+
+#if FOO
+#   define D(a, ...) B(FOO(a, __LINE__, __VA_ARGS__))
+#   define C(msg)           \
+        PP_WRAP_CODE(       \
+            if (!msg)       \
+            {               \
+                BAR();      \
+                BARBAR();   \
+                BARBARBAR();\
+            })
+#else
+#   define C(msg, ...)      EMPTY
+#endif

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -41,3 +41,4 @@
 10077 staging/Uncrustify.CSharp.cfg staging/UNI-1919.cs
 10100 staging/issue_564.cfg staging/issue_564.cpp
 10101 staging/issue_574.cfg staging/issue_574.cpp
+10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -33,6 +33,7 @@
 10036 staging/Uncrustify.Cpp.cfg staging/inttypes.h.mm
 10044 staging/Uncrustify.CSharp.cfg staging/ifcomment.cs
 10046 staging/Uncrustify.Cpp.cfg    staging/UNI-1333.mm
+10047 staging/Uncrustify.Cpp.cfg    staging/UNI-1334.cpp
 10048 staging/Uncrustify.Cpp.cfg    staging/UNI-1335.cpp
 10069 staging/Uncrustify.Cpp.cfg    staging/UNI-1980.cpp
 10070 staging/Uncrustify.Cpp.cfg    staging/UNI-1981.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -46,3 +46,4 @@
 10074 staging/Uncrustify.CSharp.cfg staging/UNI-2020.cs
 10075 staging/Uncrustify.CSharp.cfg staging/UNI-2021.cs
 10076 staging/Uncrustify.Cpp.cfg    staging/UNI-1343.cs
+10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -21,7 +21,6 @@
 10042 staging/Uncrustify.Cpp.cfg staging/indent-bad.mm
 10043 staging/Uncrustify.CSharp.cfg staging/nl-brace.cs
 10045 staging/Uncrustify.CSharp.cfg staging/UNI-1288.cs
-10047 staging/Uncrustify.Cpp.cfg    staging/UNI-1334.cpp
 10049 staging/Uncrustify.Cpp.cfg    staging/UNI-1336.cpp
 10050 staging/Uncrustify.Cpp.cfg    staging/UNI-1337.cpp
 10051 staging/Uncrustify.CSharp.cfg staging/UNI-1338.cs

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -46,4 +46,3 @@
 10074 staging/Uncrustify.CSharp.cfg staging/UNI-2020.cs
 10075 staging/Uncrustify.CSharp.cfg staging/UNI-2021.cs
 10076 staging/Uncrustify.Cpp.cfg    staging/UNI-1343.cs
-10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm


### PR DESCRIPTION
Changed the way we are tokenizing PP_IGNORE. Previously we were forcing every `define` token to be PP_IGNORE but that didn't worked for multiline defines.

With this we're instead tokenizing the body of a define with PP_IGNORE avoiding doing any extra formatting for these tokens.
