### PR TITLE
Fix for indentation after return

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1644,16 +1644,22 @@ void indent_text(void)
          /* don't count returns inside a () or [] */
          if (pc->level == pc->brace_level)
          {
-            indent_pse_push(frm, pc);
-            if (chunk_is_newline(chunk_get_next(pc)))
+            next = chunk_get_next(pc);
+            // Avoid indentation on return token if the next token is a new token
+            // to properly indent object initializers returned by functions.
+            if (!cpd.settings[UO_indent_new_after_return].b || next == NULL || next->type != CT_NEW)
             {
-               frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent + indent_size;
+               indent_pse_push(frm, pc);
+               if (chunk_is_newline(next))
+               {
+                  frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent + indent_size;
+               }
+               else
+               {
+                  frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent + pc->len() + 1;
+               }
+               frm.pse[frm.pse_tos].indent_tmp = frm.pse[frm.pse_tos - 1].indent;
             }
-            else
-            {
-               frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent + pc->len() + 1;
-            }
-            frm.pse[frm.pse_tos].indent_tmp = frm.pse[frm.pse_tos - 1].indent;
          }
       }
       else if ((pc->type == CT_OC_SCOPE) || (pc->type == CT_TYPEDEF))

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1647,10 +1647,10 @@ void indent_text(void)
             next = chunk_get_next(pc);
             // Avoid indentation on return token if the next token is a new token
             // to properly indent object initializers returned by functions.
-            if (!cpd.settings[UO_indent_new_after_return].b || next == NULL || next->type != CT_NEW)
+            if (!cpd.settings[UO_indent_off_after_return_new].b || next == NULL || next->type != CT_NEW)
             {
                indent_pse_push(frm, pc);
-               if (chunk_is_newline(next) || (pc->type == CT_RETURN && cpd.settings[UO_indent_return_single].b))
+               if (chunk_is_newline(next) || (pc->type == CT_RETURN && cpd.settings[UO_indent_single_after_return].b))
                {
                   // apply normal single indentation
                   frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent + indent_size;

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1650,12 +1650,14 @@ void indent_text(void)
             if (!cpd.settings[UO_indent_new_after_return].b || next == NULL || next->type != CT_NEW)
             {
                indent_pse_push(frm, pc);
-               if (chunk_is_newline(next))
+               if (chunk_is_newline(next) || (pc->type == CT_RETURN && cpd.settings[UO_indent_return_single].b))
                {
+                  // apply normal single indentation
                   frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent + indent_size;
                }
                else
                {
+                  // indent after the return token
                   frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent + pc->len() + 1;
                }
                frm.pse[frm.pse_tos].indent_tmp = frm.pse[frm.pse_tos - 1].indent;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -755,9 +755,9 @@ void register_options(void)
    unc_add_option("indent_cpp_lambda_body", UO_indent_cpp_lambda_body, AT_BOOL,
                   "If true, cpp lambda body will be indented.");
 
-   unc_add_option("indent_new_after_return", UO_indent_new_after_return, AT_BOOL,
+   unc_add_option("indent_off_after_return_new", UO_indent_off_after_return_new, AT_BOOL,
                   "If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.");
-   unc_add_option("indent_return_single", UO_indent_return_single, AT_BOOL,
+   unc_add_option("indent_single_after_return", UO_indent_single_after_return, AT_BOOL,
                   "If true, the tokens after return are indented with regular single indentation."
                   "By default (false) the indentation is after the return token.");
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -757,6 +757,10 @@ void register_options(void)
 
    unc_add_option("indent_new_after_return", UO_indent_new_after_return, AT_BOOL,
                   "If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.");
+   unc_add_option("indent_return_single", UO_indent_return_single, AT_BOOL,
+                  "If true, the tokens after return are indented with regular single indentation."
+                  "By default (false) the indentation is after the return token.");
+
 
    unc_begin_group(UG_newline, "Newline adding and removing options");
    unc_add_option("nl_collapse_empty_body", UO_nl_collapse_empty_body, AT_BOOL,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -755,6 +755,9 @@ void register_options(void)
    unc_add_option("indent_cpp_lambda_body", UO_indent_cpp_lambda_body, AT_BOOL,
                   "If true, cpp lambda body will be indented.");
 
+   unc_add_option("indent_new_after_return", UO_indent_new_after_return, AT_BOOL,
+                  "If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.");
+
    unc_begin_group(UG_newline, "Newline adding and removing options");
    unc_add_option("nl_collapse_empty_body", UO_nl_collapse_empty_body, AT_BOOL,
                   "Whether to collapse empty blocks between '{' and '}'");

--- a/src/options.h
+++ b/src/options.h
@@ -209,7 +209,8 @@ enum uncrustify_options
 
    UO_indent_cpp_lambda_body,        // indent cpp lambda or not
 
-   UO_indent_new_after_return,
+   UO_indent_new_after_return,       // indent 'return new' construct to the indentation of the token before the return
+   UO_indent_return_single,          // indent return to a single indentation rather than after the return token (default)
 
    /*
     * Misc inter-element spacing

--- a/src/options.h
+++ b/src/options.h
@@ -209,6 +209,8 @@ enum uncrustify_options
 
    UO_indent_cpp_lambda_body,        // indent cpp lambda or not
 
+   UO_indent_new_after_return,
+
    /*
     * Misc inter-element spacing
     */

--- a/src/options.h
+++ b/src/options.h
@@ -209,8 +209,8 @@ enum uncrustify_options
 
    UO_indent_cpp_lambda_body,        // indent cpp lambda or not
 
-   UO_indent_new_after_return,       // indent 'return new' construct to the indentation of the token before the return
-   UO_indent_return_single,          // indent return to a single indentation rather than after the return token (default)
+   UO_indent_off_after_return_new,   // indent 'return new' construct to the indentation of the token before the return
+   UO_indent_single_after_return,    // indent return to a single indentation rather than after the return token (default)
 
    /*
     * Misc inter-element spacing

--- a/tests/config/staging/Uncrustify.CSharp.cfg
+++ b/tests/config/staging/Uncrustify.CSharp.cfg
@@ -7,3 +7,4 @@ include Uncrustify.Common-CStyle.cfg
 warn_level_tabs_found_in_verbatim_string_literals=2
 
 indent_new_after_return=true
+indent_return_single=true

--- a/tests/config/staging/Uncrustify.CSharp.cfg
+++ b/tests/config/staging/Uncrustify.CSharp.cfg
@@ -5,3 +5,5 @@ include Uncrustify.Common-CStyle.cfg
 # downgrade this to warning. we have over 200 files (mostly tests) that need manual fixup including their comparison
 # targets, plus re-testing, before we can have the warning set as an error.
 warn_level_tabs_found_in_verbatim_string_literals=2
+
+indent_new_after_return=true

--- a/tests/config/staging/Uncrustify.CSharp.cfg
+++ b/tests/config/staging/Uncrustify.CSharp.cfg
@@ -6,5 +6,5 @@ include Uncrustify.Common-CStyle.cfg
 # targets, plus re-testing, before we can have the warning set as an error.
 warn_level_tabs_found_in_verbatim_string_literals=2
 
-indent_new_after_return=true
-indent_return_single=true
+indent_off_after_return_new=true
+indent_single_after_return=true

--- a/tests/input/staging/UNI-1288.cs
+++ b/tests/input/staging/UNI-1288.cs
@@ -1,27 +1,77 @@
 public class Class
 {
-    public Foo GetFoo()
-    {
-        return new Foo
-           {
-               enabled = false,
-               showDebug = false,
-               middleGrey = 0.5f,
-               min = -3f,
-               max = 3f,
-               speed = 1.5f
-           };
-    }
+	public Foo GetFoo()
+	{
+		return new Foo
+			{
+				enabled = false,
+			};
+	}
 
+	public override Bar GetBar()
+	{
+		return new Bar()
+		{
+			m_Name = TestPropertyName
+		};
+		return new
+			AA();
+		return new AA<Type>
+			{
 
-    public override Bar GetBar()
-    {
-        return new Bar()
-        {
-            m_Name = TestPropertyName
-        };
-    }
+			};
+	}
 
-    //It appears uncrustify is adding double-indentation no matter what, to the initializer block.
-    // Both of the above examples start out at a different level of indentation, and both get double-indented past original.
+	//It appears uncrustify is adding double-indentation no matter what, to the initializer block.
+	// Both of the above examples start out at a different level of indentation, and both get double-indented past original.
+}
+
+// The following code consolidates examples from the topic.
+class ObjInitializers
+{
+	class Cat
+	{
+		// Auto-implemented properties.
+		public int Age { get; set; }
+		public string Name { get; set; }
+	}
+
+	static void Main()
+	{
+		Cat cat = new Cat { Age = 10, Name = "Fluffy" };
+
+		List<Cat> cats = new List<Cat>
+			{
+				new Cat(){ Name = "Sylvester", Age=8 },
+				new Cat(){ Name = "Whiskers", Age=2 },
+				new Cat(){ Name = "Sasha", Age=14 }
+			};
+
+		List<Cat> moreCats = new List<Cat>
+	{
+		new Cat(){ Name = "Furrytail", Age=5 },
+		new Cat(){ Name = "Peaches", Age=4 },
+		null
+	};
+
+		// Display results.
+		System.Console.WriteLine(cat.Name);
+
+		foreach (Cat c in cats)
+			System.Console.WriteLine(c.Name);
+
+		foreach (Cat c in moreCats)
+			if (c != null)
+				System.Console.WriteLine(c.Name);
+			else
+				System.Console.WriteLine("List element has null value.");
+	}
+	// Output:
+	//Fluffy
+	//Sylvester
+	//Whiskers
+	//Sasha
+	//Furrytail
+	//Peaches
+	//List element has null value.
 }

--- a/tests/input/staging/UNI-2506.cs
+++ b/tests/input/staging/UNI-2506.cs
@@ -1,0 +1,12 @@
+public class Class
+{
+	public int property
+	{
+		get
+		{
+			return !IsModeActive(Mode.None)
+				&& !IsModeActive(Mode.Foo)
+				&& !IsModeActive(Mode.Bar);
+		}
+	}
+}

--- a/tests/output/staging/10045-UNI-1288.cs
+++ b/tests/output/staging/10045-UNI-1288.cs
@@ -3,14 +3,9 @@ public class Class
     public Foo GetFoo()
     {
         return new Foo
-            {
-                enabled = false,
-                showDebug = false,
-                middleGrey = 0.5f,
-                min = -3f,
-                max = 3f,
-                speed = 1.5f
-            };
+        {
+            enabled = false,
+        };
     }
 
     public override Bar GetBar()
@@ -19,8 +14,64 @@ public class Class
         {
             m_Name = TestPropertyName
         };
+        return new
+        AA();
+        return new AA<Type>
+        {
+        };
     }
 
     //It appears uncrustify is adding double-indentation no matter what, to the initializer block.
     // Both of the above examples start out at a different level of indentation, and both get double-indented past original.
+}
+
+// The following code consolidates examples from the topic.
+class ObjInitializers
+{
+    class Cat
+    {
+        // Auto-implemented properties.
+        public int Age { get; set; }
+        public string Name { get; set; }
+    }
+
+    static void Main()
+    {
+        Cat cat = new Cat { Age = 10, Name = "Fluffy" };
+
+        List<Cat> cats = new List<Cat>
+        {
+            new Cat() { Name = "Sylvester", Age = 8 },
+            new Cat() { Name = "Whiskers", Age = 2 },
+            new Cat() { Name = "Sasha", Age = 14 }
+        };
+
+        List<Cat> moreCats = new List<Cat>
+        {
+            new Cat() { Name = "Furrytail", Age = 5 },
+            new Cat() { Name = "Peaches", Age = 4 },
+            null
+        };
+
+        // Display results.
+        System.Console.WriteLine(cat.Name);
+
+        foreach (Cat c in cats)
+            System.Console.WriteLine(c.Name);
+
+        foreach (Cat c in moreCats)
+            if (c != null)
+                System.Console.WriteLine(c.Name);
+            else
+                System.Console.WriteLine("List element has null value.");
+    }
+
+    // Output:
+    //Fluffy
+    //Sylvester
+    //Whiskers
+    //Sasha
+    //Furrytail
+    //Peaches
+    //List element has null value.
 }

--- a/tests/output/staging/10103-UNI-2506.cs
+++ b/tests/output/staging/10103-UNI-2506.cs
@@ -1,0 +1,12 @@
+public class Class
+{
+    public int property
+    {
+        get
+        {
+            return !IsModeActive(Mode.None)
+                && !IsModeActive(Mode.Foo)
+                && !IsModeActive(Mode.Bar);
+        }
+    }
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -47,3 +47,4 @@
 10100 staging/issue_564.cfg staging/issue_564.cpp
 10101 staging/issue_574.cfg staging/issue_574.cpp
 10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm
+10103 staging/Uncrustify.CSharp.cfg staging/UNI-2506.cs

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -33,6 +33,7 @@
 10036 staging/Uncrustify.Cpp.cfg staging/inttypes.h.mm
 10044 staging/Uncrustify.CSharp.cfg staging/ifcomment.cs
 10046 staging/Uncrustify.Cpp.cfg    staging/UNI-1333.mm
+10045 staging/Uncrustify.CSharp.cfg staging/UNI-1288.cs
 10047 staging/Uncrustify.Cpp.cfg    staging/UNI-1334.cpp
 10048 staging/Uncrustify.Cpp.cfg    staging/UNI-1335.cpp
 10052 staging/Uncrustify.Cpp.cfg    staging/UNI-1339.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -20,7 +20,6 @@
 
 10042 staging/Uncrustify.Cpp.cfg staging/indent-bad.mm
 10043 staging/Uncrustify.CSharp.cfg staging/nl-brace.cs
-10045 staging/Uncrustify.CSharp.cfg staging/UNI-1288.cs
 10049 staging/Uncrustify.Cpp.cfg    staging/UNI-1336.cpp
 10050 staging/Uncrustify.Cpp.cfg    staging/UNI-1337.cpp
 10051 staging/Uncrustify.CSharp.cfg staging/UNI-1338.cs


### PR DESCRIPTION
Added two options to bypass the default indenting behavior:
- `indent_new_after_return` = use indentation on the return start column
- `indent_return_single` = use regular single indentation and not the special indent to return end column + 1
