### PR TITLE
Fixing bug where we would introduce digraphs when global scope qualif…

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -753,7 +753,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
       // special: if we're not supporting digraphs, then we shouldn't create them!
       if ((op == AV_REMOVE) &&
           !cpd.settings[UO_enable_digraphs].b &&
-          (first->type == CT_ANGLE_OPEN) && (second->str[0] == ':') && (second->str[1] == ':'))
+          (first->type == CT_ANGLE_OPEN) && (second->type == CT_DC_MEMBER))
       {
          op = AV_IGNORE;
       }

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -747,7 +747,18 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int& min_sp, bool comp
        (second->type == CT_ANGLE_CLOSE))
    {
       log_rule("sp_inside_angle");
-      return(cpd.settings[UO_sp_inside_angle].a);
+
+      argval_t op = cpd.settings[UO_sp_inside_angle].a;
+
+      // special: if we're not supporting digraphs, then we shouldn't create them!
+      if ((op == AV_REMOVE) &&
+          !cpd.settings[UO_enable_digraphs].b &&
+          (first->type == CT_ANGLE_OPEN) && (second->str[0] == ':') && (second->str[1] == ':'))
+      {
+         op = AV_IGNORE;
+      }
+
+      return(op);
    }
    if (second->type == CT_ANGLE_OPEN)
    {

--- a/tests/input/staging/UNI-9650.cpp
+++ b/tests/input/staging/UNI-9650.cpp
@@ -1,0 +1,7 @@
+// make sure that we ignore sp_inside_angle=remove if it will cause a digraph to be created
+
+ops.pProgressCallback = reinterpret_cast<      ::ProgressCallback*    >(   progressCallback);
+ops.pProgressCallback = reinterpret_cast< ::ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast<::ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast<ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast<  ProgressCallback*>(progressCallback);

--- a/tests/output/cpp/31001-digraph.cpp
+++ b/tests/output/cpp/31001-digraph.cpp
@@ -1,4 +1,4 @@
-x = reinterpret_cast<::Symbol *>();
+x = reinterpret_cast< ::Symbol *>();
 
 int b()
 {

--- a/tests/output/staging/10079-UNI-9650.cpp
+++ b/tests/output/staging/10079-UNI-9650.cpp
@@ -1,0 +1,7 @@
+// make sure that we ignore sp_inside_angle=remove if it will cause a digraph to be created
+
+ops.pProgressCallback = reinterpret_cast<      ::ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast< ::ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast< ::ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast<ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast<ProgressCallback*>(progressCallback);

--- a/tests/output/staging/10079-UNI-9650.cpp
+++ b/tests/output/staging/10079-UNI-9650.cpp
@@ -2,6 +2,6 @@
 
 ops.pProgressCallback = reinterpret_cast<      ::ProgressCallback*>(progressCallback);
 ops.pProgressCallback = reinterpret_cast< ::ProgressCallback*>(progressCallback);
-ops.pProgressCallback = reinterpret_cast< ::ProgressCallback*>(progressCallback);
+ops.pProgressCallback = reinterpret_cast<::ProgressCallback*>(progressCallback);
 ops.pProgressCallback = reinterpret_cast<ProgressCallback*>(progressCallback);
 ops.pProgressCallback = reinterpret_cast<ProgressCallback*>(progressCallback);

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -45,7 +45,7 @@
 10073 staging/Uncrustify.CSharp.cfg staging/UNI-2008.cs
 10077 staging/Uncrustify.CSharp.cfg staging/UNI-1919.cs
 10078 staging/Uncrustify.CSharp.cfg staging/UNI-3484.cs
-10079 staging/Uncrustify.Cpp.Cfg    staging/UNI-9650.cpp
+10079 staging/Uncrustify.Cpp.cfg    staging/UNI-9650.cpp
 10100 staging/issue_564.cfg staging/issue_564.cpp
 10101 staging/issue_574.cfg staging/issue_574.cpp
 10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -32,8 +32,8 @@
 10035 staging/Uncrustify.Cpp.cfg staging/definesalign.h.mm
 10036 staging/Uncrustify.Cpp.cfg staging/inttypes.h.mm
 10044 staging/Uncrustify.CSharp.cfg staging/ifcomment.cs
-10046 staging/Uncrustify.Cpp.cfg    staging/UNI-1333.mm
 10045 staging/Uncrustify.CSharp.cfg staging/UNI-1288.cs
+10046 staging/Uncrustify.Cpp.cfg    staging/UNI-1333.mm
 10047 staging/Uncrustify.Cpp.cfg    staging/UNI-1334.cpp
 10048 staging/Uncrustify.Cpp.cfg    staging/UNI-1335.cpp
 10052 staging/Uncrustify.Cpp.cfg    staging/UNI-1339.cpp
@@ -44,9 +44,10 @@
 10072 staging/Uncrustify.CSharp.cfg staging/UNI-2007.cs
 10073 staging/Uncrustify.CSharp.cfg staging/UNI-2008.cs
 10077 staging/Uncrustify.CSharp.cfg staging/UNI-1919.cs
+10078 staging/Uncrustify.CSharp.cfg staging/UNI-3484.cs
+10079 staging/Uncrustify.Cpp.Cfg    staging/UNI-9650.cpp
 10100 staging/issue_564.cfg staging/issue_564.cpp
 10101 staging/issue_574.cfg staging/issue_574.cpp
 10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm
 10103 staging/Uncrustify.CSharp.cfg staging/UNI-2506.cs
 10104 staging/Uncrustify.CSharp.cfg staging/UNI-2505.cs
-10078 staging/Uncrustify.CSharp.cfg staging/UNI-3484.cs


### PR DESCRIPTION
…ier was used inside a template.

Not sure why Ben's version of the digraph test explicitly has space removal with digraph creation, but that seems like a bug also. Definitely causes problems with gcc when it discovers the '<:' sequence.