### PR TITLE
Fixes asm block indent bug

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1698,6 +1698,28 @@ void indent_text(void)
          }
       }
       else if (  pc->type == CT_PAREN_OPEN
+              && (pc->parent_type == CT_ASM || chunk_get_prev_ncnl(pc)->type == CT_ASM)
+              && cpd.settings[UO_indent_ignore_asm_block].b)
+      {
+         int     move = 0;
+         chunk_t *tmp = chunk_skip_to_match(pc);
+         if (  chunk_is_newline(chunk_get_prev(pc))
+            && pc->column != indent_column)
+         {
+            move = indent_column - pc->column;
+         }
+         else
+         {
+            move = pc->column - pc->orig_col;
+         }
+         do
+         {
+            pc->column = pc->orig_col + move;
+            pc         = chunk_get_next(pc);
+         } while (pc != tmp);
+         reindent_line(pc, indent_column);
+      }
+      else if (  pc->type == CT_PAREN_OPEN
               || pc->type == CT_SPAREN_OPEN
               || pc->type == CT_FPAREN_OPEN
               || pc->type == CT_SQUARE_OPEN

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -920,7 +920,8 @@ void register_options(void)
    unc_add_option("indent_single_after_return", UO_indent_single_after_return, AT_BOOL,
                   "If true, the tokens after return are indented with regular single indentation."
                   "By default (false) the indentation is after the return token.");
-
+   unc_add_option("indent_ignore_asm_block", UO_indent_ignore_asm_block, AT_BOOL,
+                  "If true, ignore indent and align for asm blocks as they have their own indentation.");
    unc_begin_group(UG_newline, "Newline adding and removing options");
    unc_add_option("nl_collapse_empty_body", UO_nl_collapse_empty_body, AT_BOOL,
                   "Whether to collapse empty blocks between '{' and '}'.");

--- a/src/options.h
+++ b/src/options.h
@@ -430,6 +430,7 @@ enum uncrustify_options
    UO_indent_ternary_operator,              // indent continuation of ternary operator
    UO_indent_off_after_return_new,          // indent 'return new' construct to the indentation of the token before the return
    UO_indent_single_after_return,           // indent return to a single indentation rather than after the return token (default)
+   UO_indent_ignore_asm_block,              // ignore indent and align for asm blocks as they have their own indentation
    // UO_indent_brace_struct,      TODO: spaces to indent brace after struct/enum/union def
    // UO_indent_paren,             TODO: indent for open paren on next line (1)
    // UO_indent,                   TODO: 0=don't change indentation, 1=change indentation

--- a/tests/config/staging/UNI-1344.cfg
+++ b/tests/config/staging/UNI-1344.cfg
@@ -1,0 +1,3 @@
+include Uncrustify.Cpp.cfg
+indent_ignore_asm_block=true
+string_replace_tab_chars=false

--- a/tests/config/staging/Uncrustify.Common-CStyle.cfg
+++ b/tests/config/staging/Uncrustify.Common-CStyle.cfg
@@ -295,6 +295,9 @@ indent_off_after_return_new=true                    # { False, True }
 indent_single_after_return=true                     # { False, True }
 #  If true, the tokens after return are indented with regular single indentation.By default (false) the indentation is after the return token.
 #
+#indent_ignore_asm_block=true                     	# { False, True }
+#  If true, ignore indent and align for asm blocks as they have their own indentation.
+#
 ##
 ## Spacing options
 ##

--- a/tests/output/staging/10054-UNI-1344.cpp
+++ b/tests/output/staging/10054-UNI-1344.cpp
@@ -11,7 +11,7 @@ void foo()
     (
         "movq %0,%%xmm0\n\t"    /* asm template */
     "0:\n\t"
-        "bar    %0, [%4]\n\t"    // in template
+        "bar	%0, [%4]\n\t"   // in template
     "1:\n\t"
         : "=a", (bar)
         : "=&b", (&head), "+m", (bar)

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -45,6 +45,7 @@
 10048 staging/Uncrustify.Cpp.cfg    staging/UNI-1335.cpp
 10050 staging/Uncrustify.Cpp.cfg    staging/UNI-1337.cpp
 10052 staging/Uncrustify.Cpp.cfg    staging/UNI-1339.cpp
+10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10055 staging/Uncrustify.CSharp.cfg staging/UNI-1345.cs
 10062 staging/UNI-1356.cfg          staging/UNI-1356.cpp
 10069 staging/Uncrustify.Cpp.cfg    staging/UNI-1980.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -13,7 +13,6 @@
 10049 staging/Uncrustify.Cpp.cfg    staging/UNI-1336.cpp
 10051 staging/UNI-1338.cfg          staging/UNI-1338.cs
 10053 staging/Uncrustify.Cpp.cfg    staging/UNI-1340.cpp
-10054 staging/Uncrustify.Cpp.cfg    staging/UNI-1344.cpp
 10056 staging/UNI-1346.cfg          staging/UNI-1346.cpp
 10057 staging/Uncrustify.Cpp.cfg    staging/UNI-1347.cpp
 10058 staging/Uncrustify.Cpp.cfg    staging/UNI-1348.cpp


### PR DESCRIPTION
Ignore asm block indentation, as they have their own indentation. The content of the block will be indented relative to asm open paran. Hence in the input file asm block have to indented properly relative to its opening paran.
Option added: UO_indent_ignore_asm_block