### PR TITLE
Add logic to ignore the content of a block of code.

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -927,6 +927,30 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
       flag_asm(pc);
    }
 
+   if (pc->type == CT_IGNORE_CONTENT)
+   {
+      chunk_t *po = chunk_get_next_ncnl(pc);
+      if (!chunk_is_paren_open(po))
+      {
+         return;
+      }
+
+      chunk_t *end = chunk_skip_to_match(po);
+      if (!end)
+      {
+         return;
+      }
+      pc = chunk_get_next_ncnl(po);
+      while (pc != end)
+      {
+         set_chunk_type(pc, CT_IGNORE_CONTENT);
+         pc = chunk_get_next_ncnl(pc);
+      }
+
+      set_chunk_parent(po, CT_IGNORE_CONTENT);
+      set_chunk_parent(end, CT_IGNORE_CONTENT);
+   }
+
    // Objective C stuff
    if (cpd.lang_flags & LANG_OC)
    {

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1697,6 +1697,26 @@ void indent_text(void)
             }
          }
       }
+      else if (pc->type == CT_PAREN_OPEN && pc->parent_type == CT_IGNORE_CONTENT)
+      {
+         int     move = 0;
+         chunk_t *tmp = chunk_skip_to_match(pc);
+         if (  chunk_is_newline(chunk_get_prev(pc))
+            && pc->column != indent_column)
+         {
+            move = indent_column - pc->column;
+         }
+         else
+         {
+            move = pc->column - pc->orig_col;
+         }
+         do
+         {
+            pc->column = pc->orig_col + move;
+            pc         = chunk_get_next(pc);
+         } while (pc != tmp);
+         reindent_line(pc, indent_column);
+      }
       else if (  pc->type == CT_PAREN_OPEN
               || pc->type == CT_SPAREN_OPEN
               || pc->type == CT_FPAREN_OPEN

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -358,6 +358,9 @@ enum c_token_t
    CT_NOTHROW,      // guy 2016-03-11
    CT_WORD_,        // guy 2016-03-11
 
+   // Token to ignore the content of a block
+   CT_IGNORE_CONTENT,
+
    CT_TOKEN_COUNT_  // NOTE: Keep this the last entry because it's used as a counter.
 };
 

--- a/tests/config/staging/UNI-1344.cfg
+++ b/tests/config/staging/UNI-1344.cfg
@@ -1,0 +1,4 @@
+include Uncrustify.Cpp.cfg
+string_replace_tab_chars=false
+set IGNORE_CONTENT __asm__
+set IGNORE_CONTENT __volatile__

--- a/tests/output/staging/10054-UNI-1344.cpp
+++ b/tests/output/staging/10054-UNI-1344.cpp
@@ -11,7 +11,7 @@ void foo()
     (
         "movq %0,%%xmm0\n\t"    /* asm template */
     "0:\n\t"
-        "bar    %0, [%4]\n\t"    // in template
+        "bar	%0, [%4]\n\t"   // in template
     "1:\n\t"
         : "=a", (bar)
         : "=&b", (&head), "+m", (bar)

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -45,6 +45,7 @@
 10048 staging/Uncrustify.Cpp.cfg    staging/UNI-1335.cpp
 10050 staging/Uncrustify.Cpp.cfg    staging/UNI-1337.cpp
 10052 staging/Uncrustify.Cpp.cfg    staging/UNI-1339.cpp
+10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10055 staging/Uncrustify.CSharp.cfg staging/UNI-1345.cs
 10062 staging/UNI-1356.cfg          staging/UNI-1356.cpp
 10069 staging/Uncrustify.Cpp.cfg    staging/UNI-1980.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -13,7 +13,7 @@
 10049 staging/Uncrustify.Cpp.cfg    staging/UNI-1336.cpp
 10051 staging/UNI-1338.cfg          staging/UNI-1338.cs
 10053 staging/Uncrustify.Cpp.cfg    staging/UNI-1340.cpp
-10054 staging/Uncrustify.Cpp.cfg    staging/UNI-1344.cpp
+10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10056 staging/UNI-1346.cfg          staging/UNI-1346.cpp
 10057 staging/Uncrustify.Cpp.cfg    staging/UNI-1347.cpp
 10058 staging/Uncrustify.Cpp.cfg    staging/UNI-1348.cpp


### PR DESCRIPTION
add logic to ignore the content of a block of code, for example asm block from issue #1236.
the whole block of code will indented properly with indent level of the file, but the indent within the block of code will not change.