### PR TITLE
Fixes space added before ellipsis variadic template bugfix

### DIFF
--- a/src/space.cpp
+++ b/src/space.cpp
@@ -579,6 +579,13 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          log_rule("FORCE");
          return(AV_FORCE);
       }
+      // U0_sp-before_ellipsis = AV_IGNORE returning AV_ADD which is causing issue 1291.
+      // To fix issue 1291
+      if (first->type == CT_WORD)
+      {
+         log_rule("IGNORE");
+         return(AV_IGNORE);
+      }
    }
    if (first->type == CT_ELLIPSIS && CharTable::IsKw1(second->str[0]))
    {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -61,3 +61,4 @@
 10104 staging/Uncrustify.CSharp.cfg staging/UNI-2505.cs
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp
 60030 staging/Uncrustify.Cpp.cfg staging/UNI-21727.cpp
+60034 staging/Uncrustify.Cpp.cfg staging/UNI-21731.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -60,6 +60,5 @@
 60031 staging/Uncrustify.Cpp.cfg staging/UNI-21728.cpp
 60032 staging/Uncrustify.Cpp.cfg staging/UNI-21729.cpp
 60033 staging/Uncrustify.CSharp.cfg staging/UNI-21730.cs
-60034 staging/Uncrustify.Cpp.cfg staging/UNI-21731.cpp
 60035 staging/Uncrustify.CSharp.cfg staging/UNI-22858.cs
 60036 staging/Uncrustify.CSharp.cfg staging/UNI-11993.cs


### PR DESCRIPTION
Fixed the issue #1291.
Added logic to ignore the space between word and ellipsis if sp_before_ellipsis = Ignore.