### PR TITLE
Fixes extra newlines are added after switch case statements on strings

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1825,6 +1825,22 @@ void fix_symbols(void)
    bool is_java = (cpd.lang_flags & LANG_JAVA) != 0;   // forcing value to bool
    for (pc = chunk_get_head(); pc != nullptr; pc = chunk_get_next_ncnl(pc))
    {
+      //To Avoid new lines in swith case before return - setting parent type of return to CT_CASE inside switch
+      //So while adding new lines before return, will check the parent_type and add the new lines
+      if (pc->type == CT_BRACE_OPEN && pc->parent_type == CT_SWITCH)
+      {
+         chunk_t *temp = pc;
+         chunk_t *bc   = chunk_skip_to_match(temp);
+         while (temp != bc)
+         {
+            temp = chunk_get_next_ncnl(temp);
+            if (temp->type == CT_RETURN)
+            {
+               set_chunk_parent(temp, CT_CASE);
+            }
+         }
+      }
+
       if (pc->type == CT_FUNC_WRAP || pc->type == CT_TYPE_WRAP)
       {
          handle_wrap(pc);

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1962,7 +1962,7 @@ static void newline_before_return(chunk_t *start)
 
    chunk_t *pc = chunk_get_prev(nl);
    if (  !pc
-      || (pc->type == CT_BRACE_OPEN || pc->type == CT_VBRACE_OPEN || pc->type == CT_CASE_COLON))
+      || (pc->type == CT_BRACE_OPEN || pc->type == CT_VBRACE_OPEN || start->parent_type == CT_CASE))
    {
       return;
    }

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1962,7 +1962,7 @@ static void newline_before_return(chunk_t *start)
 
    chunk_t *pc = chunk_get_prev(nl);
    if (  !pc
-      || (pc->type == CT_BRACE_OPEN || pc->type == CT_VBRACE_OPEN))
+      || (pc->type == CT_BRACE_OPEN || pc->type == CT_VBRACE_OPEN || pc->type == CT_CASE_COLON))
    {
       return;
    }

--- a/tests/input/staging/UNI-17253.cs
+++ b/tests/input/staging/UNI-17253.cs
@@ -1,9 +1,56 @@
-// It adds an extra newline after each case 
-switch (someString)
+// Extra test cases for  # 1257
+switch (sometext)
 {
     case "a":
-        return foo;
-
+        return 0;
     case "b":
-        return bar;
+        Console.WrieLine("hello world\n");
+        return 0;
+    case "c":
+    {
+        Console.WrieLine("hello world\n");
+        return 0;
+    }
+    case "d":
+        Console.WrieLine("hello world\n");
+
+        if (hello)
+            return 0;
+        else
+            return 1;
+
+    case "e":
+        Console.WrieLine("hello world\n");
+
+        if (hello)
+        {
+            int a;
+            int b;
+            return 0;
+        }
+
+    case "f":
+    {
+        return 0;
+    }
+    case "g":
+
+        return 0;
+
+    case "h":
+        for (i = 0; i < 10 i++)
+        {
+            a += i;
+            return 0;
+        }
+    case "i":
+
+        if (hello)
+        {
+            int a;
+            int b;
+            return 0;
+        }
+
+        return 1;
 }

--- a/tests/output/staging/60008-UNI-17253.cs
+++ b/tests/output/staging/60008-UNI-17253.cs
@@ -1,9 +1,56 @@
-// It adds an extra newline after each case
-switch (someString)
+// Extra test cases for  # 1257
+switch (sometext)
 {
     case "a":
-        return foo;
-
+        return 0;
     case "b":
-        return bar;
+        Console.WrieLine("hello world\n");
+        return 0;
+    case "c":
+    {
+        Console.WrieLine("hello world\n");
+        return 0;
+    }
+    case "d":
+        Console.WrieLine("hello world\n");
+
+        if (hello)
+            return 0;
+        else
+            return 1;
+
+    case "e":
+        Console.WrieLine("hello world\n");
+
+        if (hello)
+        {
+            int a;
+            int b;
+            return 0;
+        }
+
+    case "f":
+    {
+        return 0;
+    }
+    case "g":
+
+        return 0;
+
+    case "h":
+        for (i = 0; i < 10 i++)
+        {
+            a += i;
+            return 0;
+        }
+    case "i":
+
+        if (hello)
+        {
+            int a;
+            int b;
+            return 0;
+        }
+
+        return 1;
 }

--- a/tests/output/staging/60008-UNI-17253.cs
+++ b/tests/output/staging/60008-UNI-17253.cs
@@ -1,4 +1,4 @@
-// It adds an extra newline after each case 
+// It adds an extra newline after each case
 switch (someString)
 {
     case "a":

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -59,5 +59,6 @@
 10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm
 10103 staging/Uncrustify.CSharp.cfg staging/UNI-2506.cs
 10104 staging/Uncrustify.CSharp.cfg staging/UNI-2505.cs
+60008 staging/Uncrustify.JamCS.cfg staging/UNI-17253.cs
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp
 60030 staging/Uncrustify.Cpp.cfg staging/UNI-21727.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -37,7 +37,6 @@
 60005 staging/Uncrustify.CSharp.cfg staging/UNI-2685.cs
 60006 staging/Uncrustify.Common-CStyle.cfg staging/UNI-2049.cpp
 60007 staging/Uncrustify.CSharp.cfg staging/UNI-3083.cs
-60008 staging/Uncrustify.JamCS.cfg staging/UNI-17253.cs
 60009 staging/Uncrustify.CSharp.cfg staging/UNI-9917.cs
 60011 staging/Uncrustify.Cpp.cfg    staging/UNI-11095.mm
 60012 staging/Uncrustify.CSharp.cfg staging/UNI-12303.cs

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -13,7 +13,6 @@
 10049 staging/Uncrustify.Cpp.cfg    staging/UNI-1336.cpp
 10051 staging/UNI-1338.cfg          staging/UNI-1338.cs
 10053 staging/Uncrustify.Cpp.cfg    staging/UNI-1340.cpp
-10054 staging/Uncrustify.Cpp.cfg    staging/UNI-1344.cpp
 10056 staging/UNI-1346.cfg          staging/UNI-1346.cpp
 10057 staging/Uncrustify.Cpp.cfg    staging/UNI-1347.cpp
 10058 staging/Uncrustify.Cpp.cfg    staging/UNI-1348.cpp
@@ -61,4 +60,3 @@
 60033 staging/Uncrustify.CSharp.cfg staging/UNI-21730.cs
 60034 staging/Uncrustify.Cpp.cfg staging/UNI-21731.cpp
 60035 staging/Uncrustify.CSharp.cfg staging/UNI-22858.cs
-60036 staging/Uncrustify.CSharp.cfg staging/UNI-11993.cs


### PR DESCRIPTION
This will remove the extra line before return after case_colon

If in switch "case" is having only one line and that too "return". This change will make sure that new line will not be added before return event though following option is set
nl_before_return = true