### PR TITLE
Fixes/space removed between dc member and keyword

### DIFF
--- a/src/chunk_list.h
+++ b/src/chunk_list.h
@@ -10,6 +10,7 @@
 
 #include "uncrustify_types.h"
 #include "char_table.h"
+#include "keywords.h"
 
 
 /*
@@ -796,6 +797,16 @@ static_inline bool chunk_is_forin(chunk_t *pc)
    return(false);
 }
 
+
+/**
+ * Checks if a chunk is a keyword
+ *
+ * @return true  - the chunk is keyword
+ */
+static_inline bool chunk_is_keyword(chunk_t *pc)
+{
+   return(find_keyword_type(pc->text(), strlen(pc->text())) != CT_WORD);
+}
 
 void set_chunk_type_real(chunk_t *pc, c_token_t tt);
 

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -495,13 +495,8 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
          break;
       }
 
-      // Issue #1005
-      /* '::' at the start of an identifier is not member access, but global scope operator.
-       * Detect if previous chunk is a type and previous-previous is "friend"
-       */
-      if (  first->type == CT_TYPE
-         && first->prev != nullptr
-         && first->prev->type == CT_FRIEND)
+      // force space between '::' and keyword, since it is a return type.
+      if (second->parent_type == CT_FUNC_START)
       {
          log_rule("FORCE");
          return(AV_FORCE);

--- a/src/token_enum.h
+++ b/src/token_enum.h
@@ -217,6 +217,7 @@ enum c_token_t
    CT_FUNC_TYPE,        // function type - foo in "typedef void (*foo)(void)"
    CT_FUNC_VAR,         // foo and parent type of first parens in "void (*foo)(void)"
    CT_FUNC_PROTO,       // function prototype
+   CT_FUNC_START,       // global DC member for functions(void ::func())
    CT_FUNC_CLASS_DEF,   // ctor or dtor for a class
    CT_FUNC_CLASS_PROTO, // ctor or dtor for a class
    CT_FUNC_CTOR_VAR,    // variable or class initialization

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -64,3 +64,5 @@
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp
 60030 staging/Uncrustify.Cpp.cfg staging/UNI-21727.cpp
 60034 staging/Uncrustify.Cpp.cfg staging/UNI-21731.cpp
+10080 staging/UNI-10496.cfg         staging/UNI-10496.cpp
+60031 staging/Uncrustify.Cpp.cfg staging/UNI-21728.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -28,7 +28,6 @@
 10074 staging/Uncrustify.CSharp.cfg staging/UNI-2020.cs
 10075 staging/Uncrustify.CSharp.cfg staging/UNI-2021.cs
 10076 staging/Uncrustify.CSharp.cfg staging/UNI-1343.cs
-10080 staging/UNI-10496.cfg         staging/UNI-10496.cpp
 60001 staging/Uncrustify.Cpp.cfg    staging/UNI-2650.cpp
 60002 staging/Uncrustify.Cpp.cfg    staging/UNI-16283.cpp
 60003 staging/Uncrustify.Cpp.cfg    staging/UNI-2680.cpp
@@ -55,7 +54,6 @@
 60027 staging/Uncrustify.Cpp.cfg staging/UNI-21506.cpp
 60028 staging/Uncrustify.Cpp.cfg staging/UNI-21509.cpp
 60029 staging/Uncrustify.Cpp.cfg staging/UNI-21510.cpp
-60031 staging/Uncrustify.Cpp.cfg staging/UNI-21728.cpp
 60032 staging/Uncrustify.Cpp.cfg staging/UNI-21729.cpp
 60033 staging/Uncrustify.CSharp.cfg staging/UNI-21730.cs
 60035 staging/Uncrustify.CSharp.cfg staging/UNI-22858.cs


### PR DESCRIPTION
Fixes issues 1249 and 1005. 1288 issue is caused by the previous fix for 1005.
Corrected the fix for 1005, so that issue 1288 will be resolved.