### PR TITLE
Fixes issue #1260 #1268 #1277

### DIFF
--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1933,6 +1933,16 @@ void indent_text(void)
          next = chunk_get_next(pc);
          if (next != nullptr)
          {
+            /*
+             * fixes  1260 , 1268 , 1277 (Extra indentation after line with multiple assignments)
+             * For multiple consecutive assignments in single line , the indent of all these
+             * assignments should be same and one more than this line's indent.
+             * so poping the previous assign and pushing the new one
+             */
+            if ((frm.pse[frm.pse_tos].type == CT_ASSIGN || frm.pse[frm.pse_tos].type == CT_ASSIGN_NL) && pc->type == CT_ASSIGN)
+            {
+               indent_pse_pop(frm, pc);
+            }
             indent_pse_push(frm, pc);
             if (cpd.settings[UO_indent_continue].n != 0)
             {
@@ -1968,7 +1978,7 @@ void indent_text(void)
             {
                frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - 1].indent_tmp + indent_size;
                log_indent();
-               if (pc->type == CT_ASSIGN)
+               if (pc->type == CT_ASSIGN && chunk_is_newline(next))
                {
                   frm.pse[frm.pse_tos].type       = CT_ASSIGN_NL;
                   frm.pse[frm.pse_tos].indent_tab = frm.pse[frm.pse_tos].indent;

--- a/tests/input/staging/misc-failures.cs
+++ b/tests/input/staging/misc-failures.cs
@@ -5,14 +5,14 @@ void Func()
 line");
 }
 
-x = o.Func(
-    y);
-x = o.Func2(a, b,
-    y);
+variablex = o.Func(
+    variabley);
+variablex = o.Func2(a, b,
+    variabley);
 o.Func(
-    y);
+    variabley);
 o.Func2(a, b,
-    y);
+    variabley);
 
 
 

--- a/tests/output/staging/10015-misc-failures.cs
+++ b/tests/output/staging/10015-misc-failures.cs
@@ -5,14 +5,14 @@ void Func()
 line");
 }
 
-x = o.Func(
-        y);
-x = o.Func2(a, b,
-        y);
+variablex = o.Func(
+    variabley);
+variablex = o.Func2(a, b,
+    variabley);
 o.Func(
-    y);
+    variabley);
 o.Func2(a, b,
-    y);
+    variabley);
 
 
 AnimatorStateMachine rootStateMachine = syncedIndex == -1

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -61,6 +61,9 @@
 10103 staging/Uncrustify.CSharp.cfg staging/UNI-2506.cs
 10104 staging/Uncrustify.CSharp.cfg staging/UNI-2505.cs
 60008 staging/Uncrustify.JamCS.cfg staging/UNI-17253.cs
+60012 staging/Uncrustify.CSharp.cfg staging/UNI-12303.cs
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp
+60022 staging/Uncrustify.Cpp.cfg staging/UNI-18439.cpp
+60025 staging/Uncrustify.Cpp.cfg staging/UNI-19894.cpp
 60030 staging/Uncrustify.Cpp.cfg staging/UNI-21727.cpp
 60034 staging/Uncrustify.Cpp.cfg staging/UNI-21731.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -38,7 +38,6 @@
 60007 staging/Uncrustify.CSharp.cfg staging/UNI-3083.cs
 60009 staging/Uncrustify.CSharp.cfg staging/UNI-9917.cs
 60011 staging/Uncrustify.Cpp.cfg    staging/UNI-11095.mm
-60012 staging/Uncrustify.CSharp.cfg staging/UNI-12303.cs
 60013 staging/Uncrustify.CSharp.cfg staging/UNI-13955.cs
 60014 staging/Uncrustify.Cpp.cfg    staging/UNI-14107.cpp
 60015 staging/Uncrustify.CSharp.cfg staging/UNI-14131.cs
@@ -47,10 +46,8 @@
 60019 staging/Uncrustify.CSharp.cfg staging/UNI-18780.cs
 60020 staging/Uncrustify.CSharp.cfg staging/UNI-18829.cs
 60021 staging/Uncrustify.Cpp.cfg staging/UNI-12046.cpp
-60022 staging/Uncrustify.Cpp.cfg staging/UNI-18439.cpp
 60023 staging/Uncrustify.CSharp.cfg staging/UNI-18437.cs
 60024 staging/Uncrustify.CSharp.cfg staging/UNI-19644.cs
-60025 staging/Uncrustify.Cpp.cfg staging/UNI-19894.cpp
 60026 staging/Uncrustify.CSharp.cfg staging/UNI-19895.cs
 60027 staging/Uncrustify.Cpp.cfg staging/UNI-21506.cpp
 60028 staging/Uncrustify.Cpp.cfg staging/UNI-21509.cpp


### PR DESCRIPTION
Setting CT_ASSIGN_NL only for pc type is CT_ASSIGN & chunk next is new line

For multiple consecutive assignments in single line , the indent of all these
assignments should be same and one more than this line's indent.
so popping the previous assign and pushing the new one

As discussed with mihai changed the test case as it contradicts uncrustify#1260 & #1268