### PR TITLE
fixes issue# 1284

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1220,10 +1220,10 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
          tmp = chunk_get_next_type(next, CT_PAREN_CLOSE, next->level);
          if (tmp != nullptr)
          {
-            chunk_t *tmpA = chunk_get_next_type(tmp, CT_ASSIGN, pc->level);
             tmp = chunk_get_next(tmp);
             if (tmp != nullptr && tmp->type == CT_PAREN_OPEN)
             {
+               chunk_t *tmpA = chunk_get_next_ncnl(chunk_get_next_type(tmp, CT_PAREN_CLOSE, tmp->level));
                if (tmpA != nullptr && tmpA->type == CT_ASSIGN)
                {
                   // we have "TYPE(...)(...) =" such as

--- a/tests/output/staging/60027-UNI-21506.cpp
+++ b/tests/output/staging/60027-UNI-21506.cpp
@@ -9,5 +9,5 @@ void Class::Foo(void (*callback)(const Class& entry))
 
 void foo()
 {
-    bool a = 1;  // if you comment this out, the bug stops reproducing
+    int a = 1;  // if you comment this out, the bug stops reproducing
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -56,6 +56,7 @@
 10077 staging/Uncrustify.CSharp.cfg staging/UNI-1919.cs
 10078 staging/Uncrustify.CSharp.cfg staging/UNI-3484.cs
 10079 staging/Uncrustify.Cpp.cfg    staging/UNI-9650.cpp
+10080 staging/UNI-10496.cfg         staging/UNI-10496.cpp
 10100 staging/issue_564.cfg staging/issue_564.cpp
 10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm
 10103 staging/Uncrustify.CSharp.cfg staging/UNI-2506.cs
@@ -64,9 +65,9 @@
 60012 staging/Uncrustify.CSharp.cfg staging/UNI-12303.cs
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp
 60022 staging/Uncrustify.Cpp.cfg staging/UNI-18439.cpp
-60025 staging/Uncrustify.Cpp.cfg staging/UNI-19894.cpp
 60024 staging/Uncrustify.CSharp.cfg staging/UNI-19644.cs
+60025 staging/Uncrustify.Cpp.cfg staging/UNI-19894.cpp
+60027 staging/Uncrustify.Cpp.cfg staging/UNI-21506.cpp
 60030 staging/Uncrustify.Cpp.cfg staging/UNI-21727.cpp
-60034 staging/Uncrustify.Cpp.cfg staging/UNI-21731.cpp
-10080 staging/UNI-10496.cfg         staging/UNI-10496.cpp
 60031 staging/Uncrustify.Cpp.cfg staging/UNI-21728.cpp
+60034 staging/Uncrustify.Cpp.cfg staging/UNI-21731.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -47,8 +47,6 @@
 60021 staging/Uncrustify.Cpp.cfg staging/UNI-12046.cpp
 60023 staging/Uncrustify.CSharp.cfg staging/UNI-18437.cs
 60026 staging/Uncrustify.CSharp.cfg staging/UNI-19895.cs
-60027 staging/Uncrustify.Cpp.cfg staging/UNI-21506.cpp
-60028 staging/Uncrustify.Cpp.cfg staging/UNI-21509.cpp
 60029 staging/Uncrustify.Cpp.cfg staging/UNI-21510.cpp
 60032 staging/Uncrustify.Cpp.cfg staging/UNI-21729.cpp
 60033 staging/Uncrustify.CSharp.cfg staging/UNI-21730.cs

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -47,6 +47,7 @@
 60021 staging/Uncrustify.Cpp.cfg staging/UNI-12046.cpp
 60023 staging/Uncrustify.CSharp.cfg staging/UNI-18437.cs
 60026 staging/Uncrustify.CSharp.cfg staging/UNI-19895.cs
+60028 staging/Uncrustify.Cpp.cfg staging/UNI-21509.cpp
 60029 staging/Uncrustify.Cpp.cfg staging/UNI-21510.cpp
 60032 staging/Uncrustify.Cpp.cfg staging/UNI-21729.cpp
 60033 staging/Uncrustify.CSharp.cfg staging/UNI-21730.cs


### PR DESCRIPTION
Modified to logic to only search for the next element after paren close for assign chunk, as chunk_get_next_type function doent limit the search to block and will search for assign in other blocks as well.