### PR TITLE
fixes wrong indentation of c# fluent style function calls

### DIFF
--- a/scripts/More_Options_to_Test/help.txt
+++ b/scripts/More_Options_to_Test/help.txt
@@ -70,6 +70,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 603 options and minimal documentation.
+There are currently 604 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -857,6 +857,10 @@ indent_align_assign             { False, True }
   Align continued statements at the '='. Default=True
   If False or the '=' is followed by a newline, the next line is indent one tab.
 
+indent_align_paren              { False, True }
+  Align continued statements at the '('. Default=True
+  If FALSE or the '(' is not followed by a newline, the next line indent is one tab.
+
 indent_oc_block                 { False, True }
   Indent OC blocks at brace level instead of usual rules.
 

--- a/scripts/Output/mini_d_uc.txt
+++ b/scripts/Output/mini_d_uc.txt
@@ -261,6 +261,7 @@ indent_first_bool_expr          = false
 indent_square_nl                = false
 indent_preserve_sql             = false
 indent_align_assign             = true
+indent_align_paren              = true
 indent_oc_block                 = false
 indent_oc_block_msg             = 0
 indent_oc_msg_colon             = 0

--- a/scripts/Output/mini_d_ucwd.txt
+++ b/scripts/Output/mini_d_ucwd.txt
@@ -859,6 +859,10 @@ indent_preserve_sql             = false    # false/true
 # If False or the '=' is followed by a newline, the next line is indent one tab.
 indent_align_assign             = true     # false/true
 
+# Align continued statements at the '('. Default=True
+# If FALSE or the '(' is not followed by a newline, the next line indent is one tab.
+indent_align_paren              = true     # false/true
+
 # Indent OC blocks at brace level instead of usual rules.
 indent_oc_block                 = false    # false/true
 

--- a/scripts/Output/mini_nd_uc.txt
+++ b/scripts/Output/mini_nd_uc.txt
@@ -261,6 +261,7 @@ indent_first_bool_expr          = false
 indent_square_nl                = false
 indent_preserve_sql             = false
 indent_align_assign             = true
+indent_align_paren              = true
 indent_oc_block                 = false
 indent_oc_block_msg             = 0
 indent_oc_msg_colon             = 0

--- a/scripts/Output/mini_nd_ucwd.txt
+++ b/scripts/Output/mini_nd_ucwd.txt
@@ -859,6 +859,10 @@ indent_preserve_sql             = false    # false/true
 # If False or the '=' is followed by a newline, the next line is indent one tab.
 indent_align_assign             = true     # false/true
 
+# Align continued statements at the '('. Default=True
+# If FALSE or the '(' is not followed by a newline, the next line indent is one tab.
+indent_align_paren              = true     # false/true
+
 # Indent OC blocks at brace level instead of usual rules.
 indent_oc_block                 = false    # false/true
 

--- a/src/indent.cpp
+++ b/src/indent.cpp
@@ -1799,6 +1799,21 @@ void indent_text(void)
             frm.pse[frm.pse_tos].indent_tab = frm.pse[frm.pse_tos].indent;
          }
 
+         else if (  pc->type == CT_PAREN_OPEN
+                 && !chunk_is_newline(next)
+                 && !cpd.settings[UO_indent_align_paren].b)
+         {
+            size_t sub = 1;
+            if (  (frm.pse[frm.pse_tos - 1].type == CT_ASSIGN)
+               || (frm.pse[frm.pse_tos - 1].type == CT_RETURN))
+            {
+               sub = 2;
+            }
+            frm.pse[frm.pse_tos].indent = frm.pse[frm.pse_tos - sub].indent + indent_size;
+            log_indent();
+            frm.pse[frm.pse_tos].indent_tab = frm.pse[frm.pse_tos].indent;
+            skipped                         = true;
+         }
          else if (  (  chunk_is_str(pc, "(", 1)
                     && !cpd.settings[UO_indent_paren_nl].b)
                  || (  chunk_is_str(pc, "<", 1)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -876,6 +876,9 @@ void register_options(void)
    unc_add_option("indent_align_assign", UO_indent_align_assign, AT_BOOL,
                   "Align continued statements at the '='. Default=True\n"
                   "If False or the '=' is followed by a newline, the next line is indent one tab.");
+   unc_add_option("indent_align_paren", UO_indent_align_paren, AT_BOOL,
+                  "Align continued statements at the '('. Default=True\n"
+                  "If FALSE or the '(' is not followed by a newline, the next line indent is one tab.");
    unc_add_option("indent_oc_block", UO_indent_oc_block, AT_BOOL,
                   "Indent OC blocks at brace level instead of usual rules.");
    unc_add_option("indent_oc_block_msg", UO_indent_oc_block_msg, AT_UNUM,
@@ -2429,6 +2432,7 @@ void set_option_defaults(void)
    cpd.defaults[UO_cmt_multi_first_len_minimum].u                       = 4;
    cpd.defaults[UO_indent_access_spec].n                                = 1;
    cpd.defaults[UO_indent_align_assign].b                               = true;
+   cpd.defaults[UO_indent_align_paren].b                                = true;
    cpd.defaults[UO_indent_columns].u                                    = 8;
    cpd.defaults[UO_indent_cpp_lambda_body].b                            = false;
    cpd.defaults[UO_indent_ctor_init_leading].u                          = 2;

--- a/src/options.h
+++ b/src/options.h
@@ -412,6 +412,7 @@ enum uncrustify_options
    UO_indent_square_nl,                     // indent-align under square for open followed by nl
    UO_indent_preserve_sql,                  // preserve indent of EXEC SQL statement body
    UO_indent_align_assign,                  //
+   UO_indent_align_paren,                   //  Align continued statements at the '(', to the next line is indent one tab.
    UO_indent_oc_block,                      //
    UO_indent_oc_block_msg,                  //
    UO_indent_oc_msg_colon,                  //

--- a/tests/config/staging/UNI-19895.cfg
+++ b/tests/config/staging/UNI-19895.cfg
@@ -1,0 +1,7 @@
+### This file holds rules specific to C#
+
+include Uncrustify.Common-CStyle.cfg
+
+indent_align_paren                      = false    # false/true
+#  Align continued statements at the '('. Default=True
+#  If FALSE or the '(' is not followed by a newline, the next line indent is one tab.

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -68,6 +68,7 @@
 60022 staging/Uncrustify.Cpp.cfg staging/UNI-18439.cpp
 60024 staging/Uncrustify.CSharp.cfg staging/UNI-19644.cs
 60025 staging/Uncrustify.Cpp.cfg staging/UNI-19894.cpp
+60026 staging/UNI-19895.cfg staging/UNI-19895.cs
 60027 staging/Uncrustify.Cpp.cfg staging/UNI-21506.cpp
 60030 staging/Uncrustify.Cpp.cfg staging/UNI-21727.cpp
 60031 staging/Uncrustify.Cpp.cfg staging/UNI-21728.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -45,7 +45,6 @@
 60020 staging/Uncrustify.CSharp.cfg staging/UNI-18829.cs
 60021 staging/Uncrustify.Cpp.cfg staging/UNI-12046.cpp
 60023 staging/Uncrustify.CSharp.cfg staging/UNI-18437.cs
-60026 staging/Uncrustify.CSharp.cfg staging/UNI-19895.cs
 60028 staging/Uncrustify.Cpp.cfg staging/UNI-21509.cpp
 60029 staging/Uncrustify.Cpp.cfg staging/UNI-21510.cpp
 60032 staging/Uncrustify.Cpp.cfg staging/UNI-21729.cpp


### PR DESCRIPTION
As discussed introduced new option

indent_align_paren                      = false
#  Align continued statements at the '('. Default=True
#  If FALSE or the '(' is not followed by a newline, the next line indent is one tab.