### PR TITLE
Fixed issue of bad tokenization of references 

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -1662,7 +1662,7 @@ void do_symbol_check(chunk_t *prev, chunk_t *pc, chunk_t *next)
                   || tmp->type == CT_QUALIFIER)
                {
                   set_chunk_type(prev, CT_TYPE);
-                  set_chunk_type(pc, CT_ADDR);
+                  set_chunk_type(pc, CT_BYREF);
                   chunk_flags_set(next, PCF_VAR_1ST);
                }
                else if (tmp->type == CT_DC_MEMBER)

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -857,7 +857,7 @@ static argval_t do_space(chunk_t *first, chunk_t *second, int &min_sp, bool comp
       return(cpd.settings[UO_sp_after_byref_func].a);
    }
 
-   if (first->type == CT_BYREF && CharTable::IsKw1(second->str[0]))
+   if (first->type == CT_BYREF && (CharTable::IsKw1(second->str[0]) || second->type == CT_PAREN_OPEN))
    {
       log_rule("sp_after_byref");
       return(cpd.settings[UO_sp_after_byref].a);

--- a/tests/input/staging/UNI-30628.cpp
+++ b/tests/input/staging/UNI-30628.cpp
@@ -1,0 +1,10 @@
+// Remaining issue
+extern void BillboardRenderer_RenderMultiple(const RenderBatchedData&renderData, ShaderChannelMask channels);
+
+// Regression 1 FAKE_METHOD expands to a function prototype. Could possibly use PROTO_WRAP like for FAKE_FUNCTION
+class Foo
+{
+    FAKE_FUNCTION(Bar, GetBarInfo, const BarInfo &());
+    FAKE_METHOD(Bar, GetBarInfo, const BarInfo &());
+    FAKE_FUNCTION_WITH_LOCAL_NAME(FakeGetCommonScriptingClasses, GetCommonScriptingClasses, const CommonScriptingClasses &());
+}

--- a/tests/input/staging/UNI-30628.cpp
+++ b/tests/input/staging/UNI-30628.cpp
@@ -1,6 +1,3 @@
-// Remaining issue
-extern void BillboardRenderer_RenderMultiple(const RenderBatchedData&renderData, ShaderChannelMask channels);
-
 // Regression 1 FAKE_METHOD expands to a function prototype. Could possibly use PROTO_WRAP like for FAKE_FUNCTION
 class Foo
 {

--- a/tests/output/staging/60039-UNI-30628.cpp
+++ b/tests/output/staging/60039-UNI-30628.cpp
@@ -1,0 +1,10 @@
+// Remaining issue
+extern void BillboardRenderer_RenderMultiple(const RenderBatchedData& renderData, ShaderChannelMask channels);
+
+// Regression 1 FAKE_METHOD expands to a function prototype. Could possibly use PROTO_WRAP like for FAKE_FUNCTION
+class Foo
+{
+    FAKE_FUNCTION(Bar, GetBarInfo, const BarInfo &());
+    FAKE_METHOD(Bar, GetBarInfo, const BarInfo &());
+    FAKE_FUNCTION_WITH_LOCAL_NAME(FakeGetCommonScriptingClasses, GetCommonScriptingClasses, const CommonScriptingClasses &());
+}

--- a/tests/output/staging/60039-UNI-30628.cpp
+++ b/tests/output/staging/60039-UNI-30628.cpp
@@ -1,6 +1,3 @@
-// Remaining issue
-extern void BillboardRenderer_RenderMultiple(const RenderBatchedData& renderData, ShaderChannelMask channels);
-
 // Regression 1 FAKE_METHOD expands to a function prototype. Could possibly use PROTO_WRAP like for FAKE_FUNCTION
 class Foo
 {

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -61,6 +61,7 @@
 10102 staging/Uncrustify.Cpp.cfg    staging/pp-ignore.mm
 10103 staging/Uncrustify.CSharp.cfg staging/UNI-2506.cs
 10104 staging/Uncrustify.CSharp.cfg staging/UNI-2505.cs
+60002 staging/Uncrustify.Cpp.cfg    staging/UNI-16283.cpp
 60003 staging/Uncrustify.Cpp.cfg    staging/UNI-1288.cpp
 60008 staging/Uncrustify.JamCS.cfg staging/UNI-17253.cs
 60012 staging/Uncrustify.CSharp.cfg staging/UNI-12303.cs

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -52,3 +52,4 @@
 60036 staging/Uncrustify.Cpp.cfg staging/UNI-2680.cpp
 60037 staging/UNI-29933.cfg staging/UNI-29933.cs
 60038 staging/UNI-30088.cfg staging/UNI-30088.cpp
+60039 staging/Uncrustify.Cpp.cfg staging/UNI-30628.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -29,7 +29,6 @@
 10075 staging/Uncrustify.CSharp.cfg staging/UNI-2021.cs
 10076 staging/Uncrustify.CSharp.cfg staging/UNI-1343.cs
 60001 staging/Uncrustify.Cpp.cfg    staging/UNI-2650.cpp
-60002 staging/Uncrustify.Cpp.cfg    staging/UNI-16283.cpp
 60004 staging/Uncrustify.CSharp.cfg staging/UNI-2684.cs
 60005 staging/Uncrustify.CSharp.cfg staging/UNI-2685.cs
 60006 staging/Uncrustify.Common-CStyle.cfg staging/UNI-2049.cpp


### PR DESCRIPTION
Fixed wrong spacing around c++ reference operator for an external function forward declared inside another function