### PR TITLE
Fixes not getting newlines for multiline braces that hug previous line

### DIFF
--- a/scripts/More_Options_to_Test/help.txt
+++ b/scripts/More_Options_to_Test/help.txt
@@ -70,6 +70,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 604 options and minimal documentation.
+There are currently 605 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -969,11 +969,11 @@ nl_end_of_file_min              Unsigned Number
 nl_assign_brace                 { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '{'.
 
-nl_tsquare_brace                { Ignore, Add, Remove, Force }
-  Add or remove newline between '[]' and '{'.
-
 nl_assign_square                { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '[' (D only).
+
+nl_tsquare_brace                { Ignore, Add, Remove, Force }
+  Add or remove newline between '[]' and '{'.
 
 nl_after_square_assign          { Ignore, Add, Remove, Force }
   Add or remove newline after '= [' (D only). Will also affect the newline before the ']'.

--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -968,7 +968,7 @@ nl_end_of_file_min              Unsigned Number
 
 nl_assign_brace                 { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '{'.
-  
+
 nl_tsquare_brace                { Ignore, Add, Remove, Force }
   Add or remove newline between '[]' and '{'.
 

--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -968,6 +968,10 @@ nl_end_of_file_min              Unsigned Number
 
 nl_assign_brace                 { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '{'.
+  
+nl_tsquare_brace                 { Ignore, Add, Remove, Force }
+  Add or remove newline between '[]' and '{'.
+
 
 nl_assign_square                { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '[' (D only).

--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -972,7 +972,6 @@ nl_assign_brace                 { Ignore, Add, Remove, Force }
 nl_tsquare_brace                 { Ignore, Add, Remove, Force }
   Add or remove newline between '[]' and '{'.
 
-
 nl_assign_square                { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '[' (D only).
 

--- a/scripts/More_Options_to_Test/show_config.txt
+++ b/scripts/More_Options_to_Test/show_config.txt
@@ -969,7 +969,7 @@ nl_end_of_file_min              Unsigned Number
 nl_assign_brace                 { Ignore, Add, Remove, Force }
   Add or remove newline between '=' and '{'.
   
-nl_tsquare_brace                 { Ignore, Add, Remove, Force }
+nl_tsquare_brace                { Ignore, Add, Remove, Force }
   Add or remove newline between '[]' and '{'.
 
 nl_assign_square                { Ignore, Add, Remove, Force }

--- a/scripts/Output/mini_d_uc.txt
+++ b/scripts/Output/mini_d_uc.txt
@@ -296,6 +296,7 @@ nl_end_of_file                  = ignore
 nl_end_of_file_min              = 0
 nl_assign_brace                 = ignore
 nl_assign_square                = ignore
+nl_tsquare_brace                = ignore
 nl_after_square_assign          = ignore
 nl_func_var_def_blk             = 0
 nl_typedef_blk_start            = 0

--- a/scripts/Output/mini_d_ucwd.txt
+++ b/scripts/Output/mini_d_ucwd.txt
@@ -974,6 +974,9 @@ nl_assign_brace                 = ignore   # ignore/add/remove/force
 # Add or remove newline between '=' and '[' (D only).
 nl_assign_square                = ignore   # ignore/add/remove/force
 
+# Add or remove newline between '[]' and '{'.
+nl_tsquare_brace                = ignore   # ignore/add/remove/force
+
 # Add or remove newline after '= [' (D only). Will also affect the newline before the ']'.
 nl_after_square_assign          = ignore   # ignore/add/remove/force
 

--- a/scripts/Output/mini_nd_uc.txt
+++ b/scripts/Output/mini_nd_uc.txt
@@ -296,6 +296,7 @@ nl_end_of_file                  = ignore
 nl_end_of_file_min              = 0
 nl_assign_brace                 = ignore
 nl_assign_square                = ignore
+nl_tsquare_brace                = ignore
 nl_after_square_assign          = ignore
 nl_func_var_def_blk             = 0
 nl_typedef_blk_start            = 0

--- a/scripts/Output/mini_nd_ucwd.txt
+++ b/scripts/Output/mini_nd_ucwd.txt
@@ -974,6 +974,9 @@ nl_assign_brace                 = ignore   # ignore/add/remove/force
 # Add or remove newline between '=' and '[' (D only).
 nl_assign_square                = ignore   # ignore/add/remove/force
 
+# Add or remove newline between '[]' and '{'.
+nl_tsquare_brace                = ignore   # ignore/add/remove/force
+
 # Add or remove newline after '= [' (D only). Will also affect the newline before the ']'.
 nl_after_square_assign          = ignore   # ignore/add/remove/force
 

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1775,6 +1775,26 @@ static void newlines_brace_pair(chunk_t *br_open)
       }
    }
 
+   //fixes #1245 will add new line between tsquare and brace open based on UO_nl_tsquare_brace
+
+   if (br_open->type == CT_BRACE_OPEN)
+   {
+      chunk_t *chunk_closeing_brace = chunk_skip_to_match(br_open, scope_e::ALL);
+      if (chunk_closeing_brace != nullptr)
+      {
+         if (chunk_closeing_brace->orig_line > br_open->orig_line)
+         {
+            prev = chunk_get_prev_nc(br_open);
+            if (  prev != nullptr
+               && prev->type == CT_TSQUARE
+               && chunk_is_newline(next))
+            {
+               newline_iarf_pair(prev, br_open, cpd.settings[UO_nl_tsquare_brace].a);
+            }
+         }
+      }
+   }
+
    // Eat any extra newlines after the brace open
    if (cpd.settings[UO_eat_blanks_after_open_brace].b)
    {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -959,6 +959,8 @@ void register_options(void)
                   "Add or remove newline between '=' and '{'.");
    unc_add_option("nl_assign_square", UO_nl_assign_square, AT_IARF,
                   "Add or remove newline between '=' and '[' (D only).");
+   unc_add_option("nl_tsquare_brace", UO_nl_tsquare_brace, AT_IARF,
+                  "Add or remove newline between '[]' and '{'.");
    unc_add_option("nl_after_square_assign", UO_nl_after_square_assign, AT_IARF,
                   "Add or remove newline after '= [' (D only). Will also affect the newline before the ']'.");
    unc_add_option("nl_func_var_def_blk", UO_nl_func_var_def_blk, AT_UNUM,
@@ -2475,6 +2477,7 @@ void set_option_defaults(void)
    cpd.defaults[UO_pp_indent_func_def].b                                = true;
    cpd.defaults[UO_pp_indent_extern].b                                  = true;
    cpd.defaults[UO_pp_indent_brace].b                                   = true;
+   cpd.defaults[UO_nl_tsquare_brace].a                                  = AV_IGNORE;
 
 #ifdef DEBUG
    // test all the default values if they are in the allowed interval

--- a/src/options.h
+++ b/src/options.h
@@ -453,6 +453,7 @@ enum uncrustify_options
    UO_nl_end_of_file_min,             // min number of newlines at the end of the file
    UO_nl_assign_brace,                // newline between '=' and '{'
    UO_nl_assign_square,               // newline between '=' and '['
+   UO_nl_tsquare_brace,               // newline between '[]' and '{'
    UO_nl_after_square_assign,         // newline after '= ['
    UO_nl_func_var_def_blk,            // newline after first block of func variable defs
    UO_nl_typedef_blk_start,           // newline before typedef block

--- a/tests/config/staging/UNI-1978.cfg
+++ b/tests/config/staging/UNI-1978.cfg
@@ -1,0 +1,5 @@
+### This file holds rules specific to C#
+
+include Uncrustify.Common-CStyle.cfg
+
+nl_tsquare_brace = add 

--- a/tests/output/staging/10067-UNI-1978.cs
+++ b/tests/output/staging/10067-UNI-1978.cs
@@ -6,14 +6,14 @@ namespace Namepsace
     {
         static Color[] colors12345636 = new[]
         {
-            new Color(123/123f, 123/123f,   0/123f),
-            new Color(123/123f, 123/123f,   4/123f),
-            new Color(123/123f,  75/123f,  36/123f),
-            new Color(123/123f,  97/123f, 136/123f),
-            new Color(123/123f, 123/123f, 136/123f),
-            new Color( 13/123f, 123/123f, 136/123f),
-            new Color(  0/123f, 123/123f, 136/123f),
-            new Color(123/123f, 123/123f,   1/123f)
+            new Color(123 / 123f, 123 / 123f,   0 / 123f),
+            new Color(123 / 123f, 123 / 123f,   4 / 123f),
+            new Color(123 / 123f,  75 / 123f,  36 / 123f),
+            new Color(123 / 123f,  97 / 123f, 136 / 123f),
+            new Color(123 / 123f, 123 / 123f, 136 / 123f),
+            new Color(13 / 123f, 123 / 123f, 136 / 123f),
+            new Color(0 / 123f, 123 / 123f, 136 / 123f),
+            new Color(123 / 123f, 123 / 123f,   1 / 123f)
         };
     }
 }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -48,7 +48,7 @@
 10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10055 staging/Uncrustify.CSharp.cfg staging/UNI-1345.cs
 10062 staging/UNI-1356.cfg          staging/UNI-1356.cpp
-10067 staging/UNI-1978.cfg 			staging/UNI-1978.cs
+10067 staging/UNI-1978.cfg 			    staging/UNI-1978.cs
 10069 staging/Uncrustify.Cpp.cfg    staging/UNI-1980.cpp
 10070 staging/Uncrustify.Cpp.cfg    staging/UNI-1981.cpp
 10071 staging/Uncrustify.Cpp.cfg    staging/UNI-1983.cpp

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -48,7 +48,7 @@
 10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10055 staging/Uncrustify.CSharp.cfg staging/UNI-1345.cs
 10062 staging/UNI-1356.cfg          staging/UNI-1356.cpp
-10067 staging/UNI-1978.cfg 			    staging/UNI-1978.cs
+10067 staging/UNI-1978.cfg          staging/UNI-1978.cs 			    
 10069 staging/Uncrustify.Cpp.cfg    staging/UNI-1980.cpp
 10070 staging/Uncrustify.Cpp.cfg    staging/UNI-1981.cpp
 10071 staging/Uncrustify.Cpp.cfg    staging/UNI-1983.cpp

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -48,6 +48,7 @@
 10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10055 staging/Uncrustify.CSharp.cfg staging/UNI-1345.cs
 10062 staging/UNI-1356.cfg          staging/UNI-1356.cpp
+10067 staging/UNI-1978.cfg 			staging/UNI-1978.cs
 10069 staging/Uncrustify.Cpp.cfg    staging/UNI-1980.cpp
 10070 staging/Uncrustify.Cpp.cfg    staging/UNI-1981.cpp
 10071 staging/Uncrustify.Cpp.cfg    staging/UNI-1983.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -23,7 +23,6 @@
 10064 staging/Uncrustify.CSharp.cfg staging/UNI-1443.cs
 10065 staging/Uncrustify.CSharp.cfg staging/UNI-1975.cs
 10066 staging/Uncrustify.CSharp.cfg staging/UNI-1977.cs
-10067 staging/Uncrustify.CSharp.cfg staging/UNI-1978.cs
 10068 staging/Uncrustify.CSharp.cfg staging/UNI-1979.cs
 10074 staging/Uncrustify.CSharp.cfg staging/UNI-2020.cs
 10075 staging/Uncrustify.CSharp.cfg staging/UNI-2021.cs


### PR DESCRIPTION
Added option nl_tsquare_brace to add or remove new line between tbrace and brace open. (1245)

Default option is Ignore