### PR TITLE
Fixed issue of adding extra space in extension methods

### DIFF
--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -937,7 +937,7 @@ static bool parse_number(tok_ctx &ctx, chunk_t &pc)
       {
          ctx.restore(ss);
          pc.type = CT_NUMBER;
-         return true;
+         return(true);
       }
       else
       {

--- a/src/tokenize.cpp
+++ b/src/tokenize.cpp
@@ -925,6 +925,25 @@ static bool parse_number(tok_ctx &ctx, chunk_t &pc)
    // Check if we stopped on a decimal point & make sure it isn't '..'
    if ((ctx.peek() == '.') && (ctx.peek(1) != '.'))
    {
+      //#issue 1265, 5.clamp()
+      tok_info ss;
+      ctx.save(ss);
+      while (ctx.more() && CharTable::IsKw2(ctx.peek(1)))
+      {
+         //skip characters to check for paren open
+         ctx.get();
+      }
+      if (ctx.peek(1) == '(')
+      {
+         ctx.restore(ss);
+         pc.type = CT_NUMBER;
+         return true;
+      }
+      else
+      {
+         ctx.restore(ss);
+      }
+
       pc.str.append(ctx.get());
       is_float = true;
       if (did_hex)

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -67,6 +67,7 @@
 60008 staging/Uncrustify.JamCS.cfg staging/UNI-17253.cs
 60012 staging/Uncrustify.CSharp.cfg staging/UNI-12303.cs
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp
+60019 staging/Uncrustify.CSharp.cfg staging/UNI-18780.cs
 60022 staging/Uncrustify.Cpp.cfg staging/UNI-18439.cpp
 60024 staging/Uncrustify.CSharp.cfg staging/UNI-19644.cs
 60025 staging/Uncrustify.Cpp.cfg staging/UNI-19894.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -39,7 +39,6 @@
 60015 staging/Uncrustify.CSharp.cfg staging/UNI-14131.cs
 60016 staging/Uncrustify.CSharp.cfg staging/UNI-11662.cs
 60018 staging/Uncrustify.CSharp.cfg staging/UNI-18777.cs
-60019 staging/Uncrustify.CSharp.cfg staging/UNI-18780.cs
 60020 staging/Uncrustify.CSharp.cfg staging/UNI-18829.cs
 60021 staging/Uncrustify.Cpp.cfg staging/UNI-12046.cpp
 60023 staging/Uncrustify.CSharp.cfg staging/UNI-18437.cs


### PR DESCRIPTION
Fixed #issue 1265 adding extra space in extension method. uncrustify tokenizing function name also part of number which is root cause for issue.