### PR TITLE
Setting indent_paren_close to 2 in unity config

### DIFF
--- a/tests/config/staging/Uncrustify.Common-CStyle.cfg
+++ b/tests/config/staging/Uncrustify.Common-CStyle.cfg
@@ -223,7 +223,7 @@ indent_access_spec=-4                               # Number
 indent_paren_nl=false                               # { False, True }
 #  If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended)
 #
-#indent_paren_close                                Number
+indent_paren_close=2                               #Number
 #  Controls the indent of a close paren after a newline.
 #  0: Indent to body level
 #  1: Align under the open paren


### PR DESCRIPTION
Setting indent_paren_close to 2