### PR TITLE
Fixes/fix for star treated as arithmetic operator in typedef

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4263,7 +4263,7 @@ static void mark_function(chunk_t *pc)
 
             // fixes issues 1005, 1288 and 1249
             // should not remove space between '::' and keyword, since it is a return type.
-            if (prev != nullptr && chunk_is_keyword(prev) && tmp->type == CT_DC_MEMBER)
+            if (chunk_is_keyword(prev) && tmp->type == CT_DC_MEMBER)
             {
                isa_def = true;
                set_chunk_parent(tmp, CT_FUNC_START);
@@ -4279,11 +4279,8 @@ static void mark_function(chunk_t *pc)
 #endif
                LOG_FMT(LFCN, " --? Skipped MEMBER and landed on %s\n",
                        (prev == NULL) ? "<null>" : get_token_name(prev->type));
-               if (tmp->type != CT_DC_MEMBER)
-               {
-                  set_chunk_type(pc, CT_FUNC_CALL);
-                  isa_def = false;
-               }
+               set_chunk_type(pc, CT_FUNC_CALL);
+               isa_def = false;
                break;
             }
             LOG_FMT(LFCN, " <skip %s>", prev->text());

--- a/tests/config/staging/UNI-2049.cfg
+++ b/tests/config/staging/UNI-2049.cfg
@@ -1,0 +1,3 @@
+include Uncrustify.Common-CStyle.cfg
+sp_before_ptr_star=remove
+sp_after_ptr_star=force

--- a/tests/output/staging/10003-633_decl-in-func-typedef.cpp
+++ b/tests/output/staging/10003-633_decl-in-func-typedef.cpp
@@ -1,2 +1,2 @@
 typedef void (*func)();
-typedef void (__stdcall * func)();
+typedef void (__stdcall *func)();

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -65,6 +65,7 @@
 60001 staging/UNI-2650.cfg          staging/UNI-2650.cpp
 60002 staging/Uncrustify.Cpp.cfg    staging/UNI-16283.cpp
 60003 staging/Uncrustify.Cpp.cfg    staging/UNI-1288.cpp
+60006 staging/UNI-2049.cfg          staging/UNI-2049.cpp
 60008 staging/Uncrustify.JamCS.cfg staging/UNI-17253.cs
 60012 staging/Uncrustify.CSharp.cfg staging/UNI-12303.cs
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -29,7 +29,6 @@
 10076 staging/Uncrustify.CSharp.cfg staging/UNI-1343.cs
 60004 staging/Uncrustify.CSharp.cfg staging/UNI-2684.cs
 60005 staging/Uncrustify.CSharp.cfg staging/UNI-2685.cs
-60006 staging/UNI-2049.cfg          staging/UNI-2049.cpp
 60007 staging/Uncrustify.CSharp.cfg staging/UNI-3083.cs
 60009 staging/Uncrustify.CSharp.cfg staging/UNI-9917.cs
 60011 staging/Uncrustify.Cpp.cfg    staging/UNI-11095.mm

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -29,7 +29,7 @@
 10076 staging/Uncrustify.CSharp.cfg staging/UNI-1343.cs
 60004 staging/Uncrustify.CSharp.cfg staging/UNI-2684.cs
 60005 staging/Uncrustify.CSharp.cfg staging/UNI-2685.cs
-60006 staging/Uncrustify.Common-CStyle.cfg staging/UNI-2049.cpp
+60006 staging/UNI-2049.cfg          staging/UNI-2049.cpp
 60007 staging/Uncrustify.CSharp.cfg staging/UNI-3083.cs
 60009 staging/Uncrustify.CSharp.cfg staging/UNI-9917.cs
 60011 staging/Uncrustify.Cpp.cfg    staging/UNI-11095.mm


### PR DESCRIPTION
Fixed issue of pointer tokenized as arithmetic operator in typedef.
To fix pointer spacing issue in #1255, existing options sp_before_ptr_star and sp_after_ptr_star are used.