### PR TITLE
fixes #1266

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4425,13 +4425,13 @@ static void mark_function(chunk_t *pc)
       // Fixes issue #1266, identification of a tuple return type in CS.
       if (  !isa_def
          && prev != nullptr
-         && chunk_is_paren_close(prev)
+         && prev->type == CT_PAREN_CLOSE
          && chunk_get_next_ncnl(prev) == pc)
       {
          tmp = chunk_skip_to_match_rev(prev);
          while (tmp != prev)
          {
-            if (tmp->type == CT_COMMA && tmp->level == prev->level)
+            if (tmp->type == CT_COMMA && tmp->level == prev->level + 1)
             {
 #ifdef DEBUG
                LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -4425,12 +4425,13 @@ static void mark_function(chunk_t *pc)
       // Fixes issue #1266, identification of a tuple return type in CS.
       if (  !isa_def
          && prev != nullptr
-         && chunk_is_paren_close(prev))
+         && chunk_is_paren_close(prev)
+         && chunk_get_next_ncnl(prev) == pc)
       {
          tmp = chunk_skip_to_match_rev(prev);
          while (tmp != prev)
          {
-            if (tmp->type == CT_COMMA)
+            if (tmp->type == CT_COMMA && tmp->level == prev->level)
             {
 #ifdef DEBUG
                LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);

--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -2055,6 +2055,13 @@ static void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t 
          }
       }
 
+      // Changing words to types into tuple return types in CS.
+      bool is_return_tuple = false;
+      if (pc != nullptr && pc->type == CT_PAREN_CLOSE)
+      {
+         first           = chunk_skip_to_match_rev(pc);
+         is_return_tuple = true;
+      }
       pc = first;
       while (pc != nullptr)
       {
@@ -2065,7 +2072,12 @@ static void mark_function_return_type(chunk_t *fname, chunk_t *start, c_token_t 
          {
             set_chunk_parent(pc, parent_type);
          }
-         make_type(pc);
+         chunk_t *prev = chunk_get_prev_ncnl(pc);
+         if (  !is_return_tuple || pc->type != CT_WORD
+            || (prev != nullptr && prev->type != CT_TYPE))
+         {
+            make_type(pc);
+         }
          if (pc == start)
          {
             break;
@@ -4408,6 +4420,28 @@ static void mark_function(chunk_t *pc)
          LOG_FMT(LFCN, " -- overriding DEF due to %s [%s]\n",
                  prev->text(), get_token_name(prev->type));
          isa_def = false;
+      }
+
+      // Fixes issue #1266, identification of a tuple return type in CS.
+      if (  !isa_def
+         && prev != nullptr
+         && chunk_is_paren_close(prev))
+      {
+         tmp = chunk_skip_to_match_rev(prev);
+         while (tmp != prev)
+         {
+            if (tmp->type == CT_COMMA)
+            {
+#ifdef DEBUG
+               LOG_FMT(LFCN, "%s(%d):", __func__, __LINE__);
+#endif
+               LOG_FMT(LFCN, " -- overriding call due to tuple return type -- %s [%s]\n",
+                       prev->text(), get_token_name(prev->type));
+               isa_def = true;
+               break;
+            }
+            tmp = chunk_get_next_ncnl(tmp);
+         }
       }
       if (isa_def)
       {

--- a/tests/input/staging/UNI-18829.cs
+++ b/tests/input/staging/UNI-18829.cs
@@ -4,3 +4,19 @@ public static (bool updated, Warnings warnings) UpdateIncludesInFile(
 {
     // ...
 }
+
+// It shouldn't detele the space after the tuple definition
+public static (int, string) UpdateIncludesInFile(
+    string fileToUpdate, string oldIncludeFile, string newIncludeFile)
+{
+    // ...
+}
+
+// It shouldn't detele the space after the tuple definition and updated, warnings should be tokenized as types
+public static (updated, warnings) UpdateIncludesInFile(
+    string fileToUpdate, string oldIncludeFile, string newIncludeFile)
+{
+    // ...
+}
+
+

--- a/tests/output/staging/60020-UNI-18829.cs
+++ b/tests/output/staging/60020-UNI-18829.cs
@@ -4,3 +4,17 @@ public static (bool updated, Warnings warnings) UpdateIncludesInFile(
 {
     // ...
 }
+
+// It shouldn't detele the space after the tuple definition
+public static (int, string) UpdateIncludesInFile(
+    string fileToUpdate, string oldIncludeFile, string newIncludeFile)
+{
+    // ...
+}
+
+// It shouldn't detele the space after the tuple definition and updated, warnings should be tokenized as types
+public static (updated, warnings) UpdateIncludesInFile(
+    string fileToUpdate, string oldIncludeFile, string newIncludeFile)
+{
+    // ...
+}

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -71,6 +71,7 @@
 60016 staging/Uncrustify.CSharp.cfg staging/UNI-11662.cs
 60017 staging/Uncrustify.Cpp.cfg    staging/UNI-2683.cpp
 60019 staging/Uncrustify.CSharp.cfg staging/UNI-18780.cs
+60020 staging/Uncrustify.CSharp.cfg staging/UNI-18829.cs
 60022 staging/Uncrustify.Cpp.cfg staging/UNI-18439.cpp
 60024 staging/Uncrustify.CSharp.cfg staging/UNI-19644.cs
 60025 staging/Uncrustify.Cpp.cfg staging/UNI-19894.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -36,7 +36,6 @@
 60014 staging/Uncrustify.Cpp.cfg    staging/UNI-14107.cpp
 60015 staging/Uncrustify.CSharp.cfg staging/UNI-14131.cs
 60018 staging/Uncrustify.CSharp.cfg staging/UNI-18777.cs
-60020 staging/Uncrustify.CSharp.cfg staging/UNI-18829.cs
 60021 staging/Uncrustify.Cpp.cfg staging/UNI-12046.cpp
 60023 staging/Uncrustify.CSharp.cfg staging/UNI-18437.cs
 60035 staging/Uncrustify.CSharp.cfg staging/UNI-22858.cs


### PR DESCRIPTION
Since uncrustify was not able to identify tuple return types, function was tokenized as a FUNC_CALL, hence considering the PAREN_CLOSE before as casting, which removed the spaces.
After identifying tuple return type, function will be tokenized as either FUNC_DEF or FUNC_PROTO, hence fixing the spacing issue.
Unidentified types in tuples were tokenized as words, which is fixed now.