### PR TITLE
fixes #1235

### DIFF
--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1757,6 +1757,32 @@ static void newlines_brace_pair(chunk_t *br_open)
       }
    }
 
+   //fixes 1235 Add single line namespace support
+
+   if (  br_open->type == CT_BRACE_OPEN
+      && (br_open->parent_type == CT_NAMESPACE)
+      && chunk_is_newline(chunk_get_prev(br_open)))
+   {
+      chunk_t *chunk_brace_close = chunk_skip_to_match(br_open, scope_e::ALL);
+      if (chunk_brace_close != nullptr)
+      {
+         if (are_chunks_in_same_line(br_open, chunk_brace_close))
+         {
+            if (cpd.settings[UO_nl_namespace_two_to_one_liner].b)
+            {
+               chunk_t *prev = chunk_get_prev_nnl(br_open);
+               newline_del_between(prev, br_open);
+            }
+            else
+            {
+               chunk_t *nxt = chunk_get_next(br_open);
+               newline_add_between(br_open, nxt);
+            }
+         }
+      }
+   }
+
+
    // Make sure we don't break a one-liner
    if (!one_liner_nl_ok(br_open))
    {

--- a/src/newlines.cpp
+++ b/src/newlines.cpp
@@ -1773,11 +1773,12 @@ static void newlines_brace_pair(chunk_t *br_open)
                chunk_t *prev = chunk_get_prev_nnl(br_open);
                newline_del_between(prev, br_open);
             }
-            else
-            {
-               chunk_t *nxt = chunk_get_next(br_open);
-               newline_add_between(br_open, nxt);
-            }
+            /* Below code is to support conversion of 2 liner to 4 liners
+             * else
+             * {
+             *  chunk_t *nxt = chunk_get_next(br_open);
+             *  newline_add_between(br_open, nxt);
+             * }*/
          }
       }
    }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1253,6 +1253,8 @@ void register_options(void)
    unc_add_option("nl_constr_colon", UO_nl_constr_colon, AT_IARF,
                   "Add or remove a newline around a class constructor colon.\n"
                   "Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.");
+   unc_add_option("nl_namespace_two_to_one_liner", UO_nl_namespace_two_to_one_liner, AT_BOOL,
+                  "If true turns two liner namespace to one liner,else will make then four liners");
    unc_add_option("nl_create_if_one_liner", UO_nl_create_if_one_liner, AT_BOOL,
                   "Change simple unbraced if statements into a one-liner\n"
                   "'if(b)\\n i++;' => 'if(b) i++;'.");

--- a/src/options.h
+++ b/src/options.h
@@ -603,6 +603,7 @@ enum uncrustify_options
    UO_nl_before_func_class_proto,     // newline before 'func_class_proto'
    UO_nl_class_colon,                 // newline before/after class colon (tied to UO_pos_class_colon)
    UO_nl_constr_colon,                // newline before/after class constr colon (tied to UO_pos_constr_colon)
+   UO_nl_namespace_two_to_one_liner,  // If true turns two liner namespace to one liner,else will make then four liners
    UO_nl_create_if_one_liner,         // Change simple unbraced if statements into a one-liner
                                       // 'if(b)\n i++;' => 'if(b) i++;'
    UO_nl_create_for_one_liner,        // Change simple unbraced for statements into a one-liner

--- a/tests/cli/Output/help.txt
+++ b/tests/cli/Output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 614 options and minimal documentation.
+There are currently 615 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/Output/help.txt
+++ b/tests/cli/Output/help.txt
@@ -69,6 +69,6 @@ Note: Use comments containing ' *INDENT-OFF*' and ' *INDENT-ON*' to disable
       processing of parts of the source file (these can be overridden with
       enable_processing_cmt and disable_processing_cmt).
 
-There are currently 613 options and minimal documentation.
+There are currently 614 options and minimal documentation.
 Try UniversalIndentGUI and good luck.
 

--- a/tests/cli/Output/mini_d_uc.txt
+++ b/tests/cli/Output/mini_d_uc.txt
@@ -422,6 +422,7 @@ nl_before_func_class_def        = 0
 nl_before_func_class_proto      = 0
 nl_class_colon                  = ignore
 nl_constr_colon                 = ignore
+nl_namespace_two_to_one_liner   = false
 nl_create_if_one_liner          = false
 nl_create_for_one_liner         = false
 nl_create_while_one_liner       = false

--- a/tests/cli/Output/mini_d_ucwd.txt
+++ b/tests/cli/Output/mini_d_ucwd.txt
@@ -1386,6 +1386,9 @@ nl_class_colon                  = ignore   # ignore/add/remove/force
 # Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
 nl_constr_colon                 = ignore   # ignore/add/remove/force
 
+# If true turns two liner namespace to one liner,else will make then four liners
+nl_namespace_two_to_one_liner   = false    # false/true
+
 # Change simple unbraced if statements into a one-liner
 # 'if(b)\n i++;' => 'if(b) i++;'.
 nl_create_if_one_liner          = false    # false/true

--- a/tests/cli/Output/mini_nd_uc.txt
+++ b/tests/cli/Output/mini_nd_uc.txt
@@ -422,6 +422,7 @@ nl_before_func_class_def        = 0
 nl_before_func_class_proto      = 0
 nl_class_colon                  = ignore
 nl_constr_colon                 = ignore
+nl_namespace_two_to_one_liner   = false
 nl_create_if_one_liner          = false
 nl_create_for_one_liner         = false
 nl_create_while_one_liner       = false

--- a/tests/cli/Output/mini_nd_ucwd.txt
+++ b/tests/cli/Output/mini_nd_ucwd.txt
@@ -1386,6 +1386,9 @@ nl_class_colon                  = ignore   # ignore/add/remove/force
 # Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
 nl_constr_colon                 = ignore   # ignore/add/remove/force
 
+# If true turns two liner namespace to one liner,else will make then four liners
+nl_namespace_two_to_one_liner   = false    # false/true
+
 # Change simple unbraced if statements into a one-liner
 # 'if(b)\n i++;' => 'if(b) i++;'.
 nl_create_if_one_liner          = false    # false/true

--- a/tests/cli/Output/show_config.txt
+++ b/tests/cli/Output/show_config.txt
@@ -1385,6 +1385,9 @@ nl_constr_colon                 { Ignore, Add, Remove, Force }
   Add or remove a newline around a class constructor colon.
   Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
 
+nl_namespace_two_to_one_liner   { False, True }
+  If true turns two liner namespace to one liner,else will make then four liners
+
 nl_create_if_one_liner          { False, True }
   Change simple unbraced if statements into a one-liner
   'if(b)\n i++;' => 'if(b) i++;'.

--- a/tests/config/staging/UNI-1340.cfg
+++ b/tests/config/staging/UNI-1340.cfg
@@ -1,0 +1,2 @@
+include Uncrustify.Common-CStyle.cfg
+nl_namespace_two_to_one_liner=true

--- a/tests/config/staging/Uncrustify.Common-CStyle.cfg
+++ b/tests/config/staging/Uncrustify.Common-CStyle.cfg
@@ -1446,6 +1446,9 @@ nl_ds_struct_enum_close_brace=false                 # { False, True }
 #  Add or remove a newline around a class constructor colon.
 #  Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
 #
+nl_namespace_two_to_one_liner=true                  # { False, True }
+#If true turns two liner namespace to one liner,else will make then four liners
+#
 nl_create_if_one_liner=false                        # { False, True }
 #  Change simple unbraced if statements into a one-liner
 #  'if(b)\n i++;' => 'if(b) i++;'

--- a/tests/config/staging/Uncrustify.Common-CStyle.cfg
+++ b/tests/config/staging/Uncrustify.Common-CStyle.cfg
@@ -1446,7 +1446,7 @@ nl_ds_struct_enum_close_brace=false                 # { False, True }
 #  Add or remove a newline around a class constructor colon.
 #  Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
 #
-nl_namespace_two_to_one_liner=true                  # { False, True }
+nl_namespace_two_to_one_liner=false                 # { False, True }
 #If true turns two liner namespace to one liner,else will make then four liners
 #
 nl_create_if_one_liner=false                        # { False, True }

--- a/tests/output/staging/10053-UNI-1340.cpp
+++ b/tests/output/staging/10053-UNI-1340.cpp
@@ -1,6 +1,3 @@
 namespace dudeNamespace { class ForwardFooClass; }
 
-namespace dudeNamespace
-{
-    class ForwardFooClass;
-}
+namespace dudeNamespace { class ForwardFooClass; }

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -45,6 +45,7 @@
 10048 staging/Uncrustify.Cpp.cfg    staging/UNI-1335.cpp
 10050 staging/Uncrustify.Cpp.cfg    staging/UNI-1337.cpp
 10052 staging/Uncrustify.Cpp.cfg    staging/UNI-1339.cpp
+10053 staging/Uncrustify.Cpp.cfg    staging/UNI-1340.cpp
 10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10055 staging/Uncrustify.CSharp.cfg staging/UNI-1345.cs
 10060 staging/UNI-1350.cfg          staging/UNI-1350.cpp

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -45,7 +45,7 @@
 10048 staging/Uncrustify.Cpp.cfg    staging/UNI-1335.cpp
 10050 staging/Uncrustify.Cpp.cfg    staging/UNI-1337.cpp
 10052 staging/Uncrustify.Cpp.cfg    staging/UNI-1339.cpp
-10053 staging/Uncrustify.Cpp.cfg    staging/UNI-1340.cpp
+10053 staging/UNI-1340.cfg          staging/UNI-1340.cpp
 10054 staging/UNI-1344.cfg          staging/UNI-1344.cpp
 10055 staging/Uncrustify.CSharp.cfg staging/UNI-1345.cs
 10060 staging/UNI-1350.cfg          staging/UNI-1350.cpp

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -12,7 +12,6 @@
 10043 staging/Uncrustify.CSharp.cfg staging/nl-brace.cs
 10049 staging/Uncrustify.Cpp.cfg    staging/UNI-1336.cpp
 10051 staging/UNI-1338.cfg          staging/UNI-1338.cs
-10053 staging/Uncrustify.Cpp.cfg    staging/UNI-1340.cpp
 10056 staging/UNI-1346.cfg          staging/UNI-1346.cpp
 10057 staging/Uncrustify.Cpp.cfg    staging/UNI-1347.cpp
 10058 staging/Uncrustify.Cpp.cfg    staging/UNI-1348.cpp


### PR DESCRIPTION
Added single line namespace support

we have introduced the option nl_namespace_two_to_one_liner which turns two liner namespace to one liner.