### PR TITLE
Fix for #1242

### DIFF
--- a/src/combine.cpp
+++ b/src/combine.cpp
@@ -3257,8 +3257,28 @@ void combine_labels(void)
                    * the CT_SIZEOF isn't great - test 31720 happens to use a sizeof expr,
                    * but this really should be able to handle any constant expr
                    */
-                  set_chunk_type(cur, CT_LABEL);
-                  set_chunk_type(next, CT_LABEL_COLON);
+                  // Fix for #1242
+                  // For MIDL_INTERFACE classes class name is tokenized as Label.
+                  // Corrected the identification of Label in c style languages.
+                  if (  (cpd.lang_flags & (LANG_C | LANG_CPP | LANG_CS))
+                     && (!(cpd.lang_flags & LANG_OC)))
+                  {
+                     chunk_t *labelPrev = prev;
+                     if (labelPrev->type == CT_NEWLINE)
+                     {
+                        labelPrev = chunk_get_prev_ncnl(prev);
+                     }
+                     if (labelPrev->type != CT_FPAREN_CLOSE)
+                     {
+                        set_chunk_type(cur, CT_LABEL);
+                        set_chunk_type(next, CT_LABEL_COLON);
+                     }
+                  }
+                  else
+                  {
+                     set_chunk_type(cur, CT_LABEL);
+                     set_chunk_type(next, CT_LABEL_COLON);
+                  }
                }
                else if (next->flags & (PCF_IN_STRUCT | PCF_IN_CLASS | PCF_IN_TYPEDEF))
                {

--- a/tests/input/cpp/nl_max_blank_in_func.cpp
+++ b/tests/input/cpp/nl_max_blank_in_func.cpp
@@ -55,7 +55,7 @@ void func0()
 //lambda function in class
 class cls
 {
-pubic:
+public:
 
 
 
@@ -118,7 +118,7 @@ namespace ns
 
 class cls
 {
-pubic:
+public:
 
 
 

--- a/tests/output/cpp/34003-nl_max_blank_in_func.cpp
+++ b/tests/output/cpp/34003-nl_max_blank_in_func.cpp
@@ -39,7 +39,7 @@ void func0()
 //lambda function in class
 class cls
 {
-pubic:
+public:
 
 
 
@@ -94,7 +94,7 @@ namespace ns
 
 class cls
 {
-pubic:
+public:
 
 
 

--- a/tests/output/cpp/34004-nl_max_blank_in_func.cpp
+++ b/tests/output/cpp/34004-nl_max_blank_in_func.cpp
@@ -51,7 +51,7 @@ void func0()
 //lambda function in class
 class cls
 {
-pubic:
+public:
 
 
 
@@ -112,7 +112,7 @@ namespace ns
 
 class cls
 {
-pubic:
+public:
 
 
 

--- a/tests/output/cpp/34005-nl_max_blank_in_func.cpp
+++ b/tests/output/cpp/34005-nl_max_blank_in_func.cpp
@@ -55,7 +55,7 @@ void func0()
 //lambda function in class
 class cls
 {
-pubic:
+public:
 
 
 
@@ -118,7 +118,7 @@ namespace ns
 
 class cls
 {
-pubic:
+public:
 
 
 

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -53,6 +53,7 @@
 10057 staging/UNI-1347.cfg          staging/UNI-1347.cpp
 10060 staging/UNI-1350.cfg          staging/UNI-1350.cpp
 10062 staging/UNI-1356.cfg          staging/UNI-1356.cpp
+10063 staging/Uncrustify.Cpp.cfg    staging/UNI-1358.cpp
 10065 staging/Uncrustify.CSharp.cfg staging/UNI-1975.cs
 10066 staging/UNI-1977.cfg          staging/UNI-1977.cs
 10067 staging/UNI-1978.cfg          staging/UNI-1978.cs 			    

--- a/tests/staging.test
+++ b/tests/staging.test
@@ -17,7 +17,6 @@
 10058 staging/Uncrustify.Cpp.cfg    staging/UNI-1348.cpp
 10059 staging/UNI-1349.cfg          staging/UNI-1349.cpp
 10061 staging/Uncrustify.CSharp.cfg staging/UNI-1355.cs
-10063 staging/Uncrustify.Cpp.cfg    staging/UNI-1358.cpp
 10064 staging/Uncrustify.CSharp.cfg staging/UNI-1443.cs
 10068 staging/Uncrustify.CSharp.cfg staging/UNI-1979.cs
 10074 staging/Uncrustify.CSharp.cfg staging/UNI-2020.cs


### PR DESCRIPTION
Fixed issue of MIDL_INTERFACE classes tokenized as Labels.
Added check for c style languages(c,cpp,cs) to identify the Labels properly.
Corrected the input and output files containing 'public' keyword misspelled.