### PR TITLE
There was a resource contention issue when invoking ctest with the pa…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_script:
 
 script:
   - make VERBOSE=1
-  - if [ "x${BUILD_TYPE}" != "xcross" ]; then ctest -V; fi
+  - if [ "x${BUILD_TYPE}" != "xcross" ]; then ctest -V -j 4; fi
     # test if all the sources are conform to the forUncrustifySources.cfg config file
   - if [ "x${BUILD_TYPE}" == "xrelease" ]; then cd ../; ./scripts/Run_uncrustify_for_sources.sh; fi
     # test if uncrustify runs for (some) command line options

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,5 +31,5 @@ build_script:
 test_script:
 #  - echo This is for test only
 #  - C:/projects/uncrustify/build/Debug/uncrustify.exe -c C:/projects/uncrustify/tests/config/mono.cfg -f C:/projects/uncrustify/tests/input/cs/simple.cs -L 66
-  - ctest -C %CONFIGURATION% -V
+  - ctest -C %CONFIGURATION% -V -j 4
 deploy: off

--- a/tests/run_test.cmake
+++ b/tests/run_test.cmake
@@ -39,21 +39,23 @@ endif()
 
 
 # first pass
+string(RANDOM LENGTH 8 ALPHABET 0123456789 test_uuid)
+
 execute_process(
   COMMAND ${TEST_PROGRAM} -l ${TEST_LANG} -c ${TEST_CONFIG} -f ${TEST_INPUT} -o ${TEST_RESULT}
     WORKING_DIRECTORY ${TEST_DIR}
     RESULT_VARIABLE uncrustify_error_code
     OUTPUT_QUIET
     ERROR_VARIABLE uncrustify_error
-    ERROR_FILE ${TEST_DIR}/ERR-1.txt
+    ERROR_FILE ${TEST_DIR}/ERR-1-${test_uuid}.txt
 )
 
 if(uncrustify_error_code)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error. The ERR-1.txt file is:"
+    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error: " ${uncrustify_error_code} "  The ERR-1-${test_uuid}.txt file is:"
   )
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-1.txt /dev/stderr
+    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-1-${test_uuid}.txt /dev/stderr
   )
   message(SEND_ERROR "Uncrustify error_code (Pass 1)")
 else(uncrustify_error_code)
@@ -73,7 +75,7 @@ else(uncrustify_error_code)
     message(SEND_ERROR "Uncrustify MISSMATCH (Pass 1)")
   endif()
 endif(uncrustify_error_code)
-file(REMOVE ${TEST_DIR}/ERR-1.txt)
+file(REMOVE ${TEST_DIR}/ERR-1-${test_uuid}.txt)
 
 
 # Re-run with the output file as the input to check stability.
@@ -83,15 +85,15 @@ execute_process(
     RESULT_VARIABLE uncrustify_error_code
     OUTPUT_QUIET
     ERROR_VARIABLE uncrustify_error
-    ERROR_FILE ${TEST_DIR}/ERR-2.txt
+    ERROR_FILE ${TEST_DIR}/ERR-2-${test_uuid}.txt
 )
 
 if(uncrustify_error_code)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error. The ERR-2.txt file is:"
+    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error: " ${uncrustify_error_code} "  The ERR-2-${test_uuid}.txt file is:"
   )
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-2.txt /dev/stderr
+    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-2-${test_uuid}.txt /dev/stderr
   )
   message(SEND_ERROR "Uncrustify error_code (Pass 2)")
 else(uncrustify_error_code)
@@ -110,4 +112,4 @@ else(uncrustify_error_code)
     message(SEND_ERROR "Uncrustify UNSTABLE (Pass 2)")
   endif()
 endif()
-file(REMOVE ${TEST_DIR}/ERR-2.txt)
+file(REMOVE ${TEST_DIR}/ERR-2-${test_uuid}.txt)

--- a/tests/run_test.cmake
+++ b/tests/run_test.cmake
@@ -38,23 +38,26 @@ if(NOT TEST_RERUN_OUTPUT)
 endif()
 
 
-# first pass
 string(MD5 test_uuid ${TEST_DIR}${TEST_INPUT}${TEST_RESULT})
+set(STDERR_PASS_1 ERR-1-${test_uuid}.txt)
+set(STDERR_PASS_2 ERR-2-${test_uuid}.txt)
+
+# first pass
 execute_process(
   COMMAND ${TEST_PROGRAM} -l ${TEST_LANG} -c ${TEST_CONFIG} -f ${TEST_INPUT} -o ${TEST_RESULT}
     WORKING_DIRECTORY ${TEST_DIR}
     RESULT_VARIABLE uncrustify_error_code
     OUTPUT_QUIET
     ERROR_VARIABLE uncrustify_error
-    ERROR_FILE ${TEST_DIR}/ERR-1-${test_uuid}.txt
+    ERROR_FILE ${TEST_DIR}/${STDERR_PASS_1}
 )
 
 if(uncrustify_error_code)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error: " ${uncrustify_error_code} "  The ERR-1-${test_uuid}.txt file is:"
+    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error: " ${uncrustify_error_code} "  The ${STDERR_PASS_1} file is:"
   )
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-1-${test_uuid}.txt /dev/stderr
+    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/${STDERR_PASS_1} /dev/stderr
   )
   message(SEND_ERROR "Uncrustify error_code (Pass 1)")
 else(uncrustify_error_code)
@@ -74,7 +77,7 @@ else(uncrustify_error_code)
     message(SEND_ERROR "Uncrustify MISSMATCH (Pass 1)")
   endif()
 endif(uncrustify_error_code)
-file(REMOVE ${TEST_DIR}/ERR-1-${test_uuid}.txt)
+file(REMOVE ${TEST_DIR}/${STDERR_PASS_1})
 
 
 # Re-run with the output file as the input to check stability.
@@ -84,15 +87,15 @@ execute_process(
     RESULT_VARIABLE uncrustify_error_code
     OUTPUT_QUIET
     ERROR_VARIABLE uncrustify_error
-    ERROR_FILE ${TEST_DIR}/ERR-2-${test_uuid}.txt
+    ERROR_FILE ${TEST_DIR}/${STDERR_PASS_2}
 )
 
 if(uncrustify_error_code)
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error: " ${uncrustify_error_code} "  The ERR-2-${test_uuid}.txt file is:"
+    COMMAND ${CMAKE_COMMAND} -E echo "Uncrustify error: " ${uncrustify_error_code} "  The ${STDERR_PASS_2} file is:"
   )
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/ERR-2-${test_uuid}.txt /dev/stderr
+    COMMAND ${CMAKE_COMMAND} -E copy ${TEST_DIR}/${STDERR_PASS_2} /dev/stderr
   )
   message(SEND_ERROR "Uncrustify error_code (Pass 2)")
 else(uncrustify_error_code)
@@ -111,4 +114,4 @@ else(uncrustify_error_code)
     message(SEND_ERROR "Uncrustify UNSTABLE (Pass 2)")
   endif()
 endif()
-file(REMOVE ${TEST_DIR}/ERR-2-${test_uuid}.txt)
+file(REMOVE ${TEST_DIR}/${STDERR_PASS_2})

--- a/tests/run_test.cmake
+++ b/tests/run_test.cmake
@@ -39,8 +39,7 @@ endif()
 
 
 # first pass
-string(RANDOM LENGTH 8 ALPHABET 0123456789 test_uuid)
-
+string(MD5 test_uuid ${TEST_DIR}${TEST_INPUT}${TEST_RESULT})
 execute_process(
   COMMAND ${TEST_PROGRAM} -l ${TEST_LANG} -c ${TEST_CONFIG} -f ${TEST_INPUT} -o ${TEST_RESULT}
     WORKING_DIRECTORY ${TEST_DIR}


### PR DESCRIPTION
…rallel flag (-j) when attempting to access the ERR-1.txt or ERR-2.txt files in the uncrustify/tests folder.

This caused ctest runs with the -j flag to randomly fail as the file system was returning an access denied issue.

Adding a random number to the .txt file name (i.e. ERR-1-1234.txt) has fixed the issue, so we no longer have the resource contention and all tests pass when running them with the parallel flag.