### PR TITLE
we have set __FAKEABLE_FUNCTION_OVERLOADED__  to  PROTO_WRAP since un…

### DIFF
--- a/tests/config/staging/Uncrustify.Common-Cpp.cfg
+++ b/tests/config/staging/Uncrustify.Common-Cpp.cfg
@@ -27,3 +27,5 @@ set COMMENT __stdcall
 set COMMENT __thiscall
 set COMMENT __vectorcall
 set COMMENT WINAPI
+set PROTO_WRAP __FAKEABLE_FUNCTION_OVERLOADED__
+

--- a/tests/input/staging/UNI-2048.cpp
+++ b/tests/input/staging/UNI-2048.cpp
@@ -1,0 +1,2 @@
+//Test Case-001
+__FAKEABLE_FUNCTION_OVERLOADED__(RegisterUndo, (identifier, inputObjects, size, actionName, namePriority), void(Object*, Object**, int, const core::string&, int));

--- a/tests/output/staging/60062-UNI-2048.cpp
+++ b/tests/output/staging/60062-UNI-2048.cpp
@@ -1,0 +1,2 @@
+//Test Case-001
+__FAKEABLE_FUNCTION_OVERLOADED__(RegisterUndo, (identifier, inputObjects, size, actionName, namePriority), void(Object*, Object**, int, const core::string&, int));

--- a/tests/regression.test
+++ b/tests/regression.test
@@ -142,3 +142,4 @@
 60055 staging/Uncrustify.Common-Cpp.cfg staging/UNI-29935.cpp
 60056 staging/Uncrustify.Common-Cpp.cfg staging/UNI-29935.cpp
 60057 staging/Uncrustify.Cpp.cfg staging/UNI-crash.cpp
+60062 staging/Uncrustify.Common-Cpp.cfg staging/UNI-2048.cpp


### PR DESCRIPTION
…crustify is unable to identify macros