### PR TITLE
Fix C# nested usings indentation

### DIFF
--- a/tests/config/staging/Uncrustify.CSharp.cfg
+++ b/tests/config/staging/Uncrustify.CSharp.cfg
@@ -1,3 +1,7 @@
 ### This file holds rules specific to C#
 
 include Uncrustify.Common-CStyle.cfg
+
+indent_using_block=false                                     # { False, True }
+#  indent (or not) an using block if no braces are used. Only for C#.Default=True.
+#

--- a/tests/config/staging/Uncrustify.Common-CStyle.cfg
+++ b/tests/config/staging/Uncrustify.Common-CStyle.cfg
@@ -928,7 +928,7 @@ indent_oc_block_msg_xcode_style=true                         # { False, True }
 #indent_cpp_lambda_body                                      { False, True }
 #  If True, cpp lambda body will be indentedDefault=False.
 #
-indent_using_block=false                                     # { False, True }
+#indent_using_block                                          { False, True }
 #  indent (or not) an using block if no braces are used. Only for C#.Default=True.
 #
 #indent_ternary_operator                                     Unsigned Number

--- a/tests/config/staging/Uncrustify.Common-CStyle.cfg
+++ b/tests/config/staging/Uncrustify.Common-CStyle.cfg
@@ -928,7 +928,7 @@ indent_oc_block_msg_xcode_style=true                         # { False, True }
 #indent_cpp_lambda_body                                      { False, True }
 #  If True, cpp lambda body will be indentedDefault=False.
 #
-#indent_using_block                                          { False, True }
+indent_using_block=false                                     # { False, True }
 #  indent (or not) an using block if no braces are used. Only for C#.Default=True.
 #
 #indent_ternary_operator                                     Unsigned Number


### PR DESCRIPTION
We want to have no indentation for nested usings, that's why we deactivate the option that does that by default.