### PR TITLE
Remove invalidated Coveralls token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      env: BUILD_TYPE=coverage COVERALLS_TOKEN="iJXKQxvt6RJMcxkn99GIhakcoCx7XvzbU"
       compiler: gcc
 
     # OSX


### PR DESCRIPTION
The Coveralls token has already been invalidated. There's no need to keep it in the repo anymore.